### PR TITLE
Fix caching bug on ee.List.shuffle(seed=False)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,4 @@ Importing `eerepr` in a Jupyter notebook adds an HTML repr method to all Earth E
 
 `eerepr` uses caching to improve performance. Server data will only be requested once for each unique Earth Engine object, and all subsequent requests will be retrieved from the cache until the Jupyter session is restarted.
 
-When you import `eerepr`, it is automatically initialized with an unlimited cache size. You can manually set the number of unique objects to cache using `eerepr.initialize(max_cache_size=n)`. A value of `None` sets an unlimited cache while a value of `0` disables caching. You can also clear out the cache contents to free memory with `eerepr.clear_cache()`.
-
-> **Warning**
-> There is a known bug when calling `ee.List.shuffle(seed=False)`. Because the method returns non-deterministic results from the same seed value, the incorrect cached result will be displayed if called multiple times. All other random methods use deterministic seeds and should work as expected.
+When you import `eerepr`, it is automatically initialized with an unlimited cache size. You can manually set the number of unique objects to cache using `eerepr.initialize(max_cache_size=n)`. A value of `None` sets an unlimited cache while a value of `0` disables caching.

--- a/eerepr/__init__.py
+++ b/eerepr/__init__.py
@@ -1,6 +1,6 @@
 import ee
 
-from eerepr.repr import clear_cache, initialize
+from eerepr.repr import initialize
 
 __version__ = '0.0.1'
 __all__ = ['clear_cache', 'initialize']

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -5,19 +5,21 @@ import ee
 import eerepr
 
 
-def test_clear_cache():
-    x = ee.Number(0)
-    x._repr_html_()
-    assert x._repr_html_.cache_info().currsize == 1
-
-    eerepr.clear_cache()
-    assert x._repr_html_.cache_info().currsize == 0
-
-
 def test_disabled_cache():
     eerepr.initialize(max_cache_size=0)
     x = ee.Number(0)
     assert not isinstance(x._repr_html_, _lru_cache_wrapper)
 
-    # This shouldn't break
-    eerepr.clear_cache()
+
+def test_nondeterministic_caching():
+    """ee.List.shuffle(seed=False) is nondeterministic. Make sure it misses the cache."""
+    eerepr.initialize(max_cache_size=None)
+    cache = eerepr.repr._repr_html_
+
+    cache.cache_clear()
+
+    assert cache.cache_info().misses == 0
+    x = ee.List([0, 1, 2]).shuffle(seed=False)
+    x._repr_html_()
+    x._repr_html_()
+    assert cache.cache_info().misses == 2


### PR DESCRIPTION
As explained in #6, `ee.List.shuffle(seed=False)` is non-deterministic and therefore returns different results from the same serialized object. This is (arguably) an underlying issue in the Earth Engine API. To prevent incorrect cache hits that would display the same data for differently shuffled lists (and objects built from shuffled lists), this PR adds a check against the serialized object. If `ee.List.shuffle(seed=False)` was used to construct the object, a randomized `_eerepr_id` attr is added to the object, causing equality checks (`ee.ComputedObject.__eq__`) to fail and the cache to miss.

To accomplish that, we had to slightly change the repr setup by wrapping the cached repr generation function `_repr_html_` in an uncached `_ee_repr` function where the deterministic check takes place. 

Close #6