### PR TITLE
Add a config module and prevent accidentally printing huge reprs

### DIFF
--- a/eerepr/__init__.py
+++ b/eerepr/__init__.py
@@ -1,10 +1,9 @@
 import ee
 
 from eerepr.repr import initialize
+from eerepr.config import options
 
 __version__ = '0.0.1'
-__all__ = ['clear_cache', 'initialize']
+__all__ = ['clear_cache', 'initialize', 'options']
 
-MAX_CACHE_SIZE = None
-
-initialize(max_cache_size=MAX_CACHE_SIZE)
+initialize(max_cache_size=options.max_cache_size)

--- a/eerepr/config.py
+++ b/eerepr/config.py
@@ -1,0 +1,16 @@
+import json
+
+
+class Config:
+    def __init__(self, max_cache_size, max_repr_mbs):
+        self.max_cache_size = max_cache_size
+        self.max_repr_mbs = max_repr_mbs
+
+    def __repr__(self):
+        return json.dumps(self.__dict__, indent=2)
+
+
+options = Config(
+    max_cache_size=None,
+    max_repr_mbs=100,
+)


### PR DESCRIPTION
This PR adds a basic `config` module with global user settings. Currently this is only really used for setting `max_repr_mbs`, which was added to prevent accidentally printing huge reprs that will crash Jupyter.

Close #8 