### PR TITLE
Fix bug with null geometry features

### DIFF
--- a/eerepr/html.py
+++ b/eerepr/html.py
@@ -110,7 +110,11 @@ def _build_date_label(obj: dict) -> str:
 
 def _build_feature_label(obj: dict) -> str:
     n = len(obj.get("properties", []))
-    geom_type = obj.get("geometry", {}).get("type")
+    try:
+        geom_type = obj["geometry"]["type"]
+    except (TypeError, KeyError):
+        geom_type = None
+
     type_label = f"{geom_type}, " if geom_type is not None else ""
     noun = "property" if n == 1 else "properties"
     return f"Feature ({type_label}{n} {noun})"

--- a/tests/test_reprs.py
+++ b/tests/test_reprs.py
@@ -35,6 +35,9 @@ def test_feature():
 
     assert "Feature (Point, 1 property)" in rep
 
+def test_empty_feature():
+    rep = ee.Feature(None)._repr_html_()
+    assert "Feature (0 properties)" in rep
 
 def test_featurecollection():
     feat = ee.Feature(geom=ee.Geometry.Point([0, 0]), opt_properties={"foo": "bar"})


### PR DESCRIPTION
Building a repr for `ee.Feature(None)` used to fail. This handles that edge cases and adds a regression test.

Close #16