### PR TITLE
Pure CSS collapsing

### DIFF
--- a/eerepr/html.py
+++ b/eerepr/html.py
@@ -70,8 +70,8 @@ def _make_collapsible_li(header: str, children: list) -> str:
     """Package a header and children into a collapsible list element."""
     return (
         "<li>"
-        f"<label class='ee-shut'>{header}"
-        "<input type='checkbox' class='ee-toggle'></label>"
+        f"<label>{header}"
+        "<input type='checkbox'></label>"
         f"<ul>{''.join(children)}</ul>"
         "</li>"
     )

--- a/eerepr/repr.py
+++ b/eerepr/repr.py
@@ -40,14 +40,6 @@ def _load_css() -> str:
     return _load_file("eerepr.static.css", "style.css")
 
 
-@lru_cache(maxsize=1)
-def _load_js() -> str:
-    """Note: JS is only needed because the CSS `:has()` selector isn't well supported
-    yet, preventing a pure CSS solution to the collapsible lists.
-    """
-    return _load_file("eerepr.static.js", "script.js")
-
-
 def _attach_html_repr(cls: type, repr: Any) -> None:
     """Add a HTML repr method to an EE class. Only overwrite the method if it was set by
     this function.
@@ -82,7 +74,6 @@ def _repr_html_(obj: EEObject) -> str:
         return f"<pre>{escape(repr(obj))}</pre>"
 
     css = _load_css()
-    js = _load_js()
     body = convert_to_html(info)
 
     return (
@@ -91,7 +82,6 @@ def _repr_html_(obj: EEObject) -> str:
         "<div class='ee'>"
         f"<ul>{body}</ul>"
         "</div>"
-        f"<script>{js}</script>"
         "</div>"
     )
 

--- a/eerepr/static/css/style.css
+++ b/eerepr/static/css/style.css
@@ -44,15 +44,13 @@ body.vscode-dark {
   padding-left: 0 !important;
 }
 
-.ee-open,
-.ee-shut {
+.ee label {
   color: var(--font-color-secondary);
   cursor: pointer;
   margin: 0;
 }
 
-.ee-open:hover,
-.ee-shut:hover {
+.ee label:hover {
   color: var(--font-color-primary);
 }
 
@@ -65,30 +63,26 @@ body.vscode-dark {
   color: var(--font-color-primary);
 }
 
-.ee-toggle {
+.ee input {
   display: none;
 }
 
-.ee-shut + ul {
+.ee label + ul {
   display: none;
 }
 
-.ee-open + ul {
+.ee label:has(input:checked) + ul {
   display: block;
 }
 
-.ee-shut::before {
+.ee label::before {
+  transform: rotate(-90deg);
   display: inline-block;
   content: "▼";
   margin-right: 6px;
-  transform: rotate(-90deg);
   transition: transform 0.2s;
 }
 
-.ee-open::before {
+.ee label:has(input:checked)::before {
   transform: rotate(0deg);
-  display: inline-block;
-  content: "▼";
-  margin-right: 6px;
-  transition: transform 0.2s;
 }

--- a/eerepr/static/js/script.js
+++ b/eerepr/static/js/script.js
@@ -1,8 +1,0 @@
-function toggleHeader() {
-    const parent = this.parentElement;
-    parent.className = parent.className === "ee-open" ? "ee-shut" : "ee-open";
-}
-
-for (let c of document.getElementsByClassName("ee-toggle")) {
-    c.onclick = toggleHeader;
-}

--- a/tests/data/test_full_repr.yml
+++ b/tests/data/test_full_repr.yml
@@ -11,250 +11,214 @@
   \ 1.5em;\n  min-width: 300px;\n  max-width: 1200px;\n  overflow-y: scroll;\n  max-height:\
   \ 600px;\n  border: 1px solid var(--border-color);\n  font-family: monospace;\n\
   }\n\n.ee li {\n  list-style-type: none;\n}\n\n.ee ul {\n  padding-left: 1.5em !important;\n\
-  \  margin: 0;\n}\n\n.ee > ul {\n  padding-left: 0 !important;\n}\n\n.ee-open,\n\
-  .ee-shut {\n  color: var(--font-color-secondary);\n  cursor: pointer;\n  margin:\
-  \ 0;\n}\n\n.ee-open:hover,\n.ee-shut:hover {\n  color: var(--font-color-primary);\n\
-  }\n\n.ee-k {\n  color: var(--font-color-accent);\n  margin-right: 6px;\n}\n\n.ee-v\
-  \ {\n  color: var(--font-color-primary);\n}\n\n.ee-toggle {\n  display: none;\n\
-  }\n\n.ee-shut + ul {\n  display: none;\n}\n\n.ee-open + ul {\n  display: block;\n\
-  }\n\n.ee-shut::before {\n  display: inline-block;\n  content: \"▼\";\n  margin-right:\
-  \ 6px;\n  transform: rotate(-90deg);\n  transition: transform 0.2s;\n}\n\n.ee-open::before\
-  \ {\n  transform: rotate(0deg);\n  display: inline-block;\n  content: \"▼\";\n \
-  \ margin-right: 6px;\n  transition: transform 0.2s;\n}\n</style><div class='ee'><ul><li><label\
-  \ class='ee-shut'>List (40 elements)<input type='checkbox' class='ee-toggle'></label><ul><li><label\
-  \ class='ee-shut'>0: Image foo (1 band)<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>type:</span><span class='ee-v'>Image</span></li><li><span class='ee-k'>id:</span><span\
-  \ class='ee-v'>foo</span></li><li><label class='ee-shut'>bands: List (1 element)<input\
-  \ type='checkbox' class='ee-toggle'></label><ul><li><label class='ee-shut'>0: \"\
-  constant\", int ∈ [0, 0], EPSG:4326<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>id:</span><span class='ee-v'>constant</span></li><li><span class='ee-k'>crs:</span><span\
-  \ class='ee-v'>EPSG:4326</span></li><li><label class='ee-shut'>crs_transform: [1,\
-  \ 0, 0, 0, 1, 0]<input type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>0:</span><span\
+  \  margin: 0;\n}\n\n.ee > ul {\n  padding-left: 0 !important;\n}\n\n.ee label {\n\
+  \  color: var(--font-color-secondary);\n  cursor: pointer;\n  margin: 0;\n}\n\n\
+  .ee label:hover {\n  color: var(--font-color-primary);\n}\n\n.ee-k {\n  color: var(--font-color-accent);\n\
+  \  margin-right: 6px;\n}\n\n.ee-v {\n  color: var(--font-color-primary);\n}\n\n\
+  .ee input {\n  display: none;\n}\n\n.ee label + ul {\n  display: none;\n}\n\n.ee\
+  \ label:has(input:checked) + ul {\n  display: block;\n}\n\n.ee label::before {\n\
+  \  transform: rotate(-90deg);\n  display: inline-block;\n  content: \"▼\";\n  margin-right:\
+  \ 6px;\n  transition: transform 0.2s;\n}\n\n.ee label:has(input:checked)::before\
+  \ {\n  transform: rotate(0deg);\n}\n</style><div class='ee'><ul><li><label>List\
+  \ (40 elements)<input type='checkbox'></label><ul><li><label>0: Image foo (1 band)<input\
+  \ type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span class='ee-v'>Image</span></li><li><span\
+  \ class='ee-k'>id:</span><span class='ee-v'>foo</span></li><li><label>bands: List\
+  \ (1 element)<input type='checkbox'></label><ul><li><label>0: \"constant\", int\
+  \ ∈ [0, 0], EPSG:4326<input type='checkbox'></label><ul><li><span class='ee-k'>id:</span><span\
+  \ class='ee-v'>constant</span></li><li><span class='ee-k'>crs:</span><span class='ee-v'>EPSG:4326</span></li><li><label>crs_transform:\
+  \ [1, 0, 0, 0, 1, 0]<input type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span\
   \ class='ee-v'>1</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>0</span></li><li><span\
   \ class='ee-k'>2:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>3:</span><span\
   \ class='ee-v'>0</span></li><li><span class='ee-k'>4:</span><span class='ee-v'>1</span></li><li><span\
-  \ class='ee-k'>5:</span><span class='ee-v'>0</span></li></ul></li><li><label class='ee-shut'>data_type:\
-  \ int ∈ [0, 0]<input type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>type:</span><span\
+  \ class='ee-k'>5:</span><span class='ee-v'>0</span></li></ul></li><li><label>data_type:\
+  \ int ∈ [0, 0]<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span\
   \ class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span class='ee-v'>0</span></li><li><span\
   \ class='ee-k'>min:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>precision:</span><span\
-  \ class='ee-v'>int</span></li></ul></li></ul></li></ul></li></ul></li><li><label\
-  \ class='ee-shut'>1: ImageCollection (0 elements)<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>type:</span><span class='ee-v'>ImageCollection</span></li><li><label\
-  \ class='ee-shut'>bands: []<input type='checkbox' class='ee-toggle'></label><ul></ul></li><li><label\
-  \ class='ee-shut'>properties: Object (1 property)<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>test_prop:</span><span class='ee-v'>42</span></li></ul></li></ul></li><li><label\
-  \ class='ee-shut'>2: Feature (Point, 1 property)<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>type:</span><span class='ee-v'>Feature</span></li><li><label class='ee-shut'>geometry:\
-  \ Point (0.00, 0.00)<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>type:</span><span class='ee-v'>Point</span></li><li><label class='ee-shut'>coordinates:\
-  \ [0, 0]<input type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>0:</span><span\
-  \ class='ee-v'>0</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>0</span></li></ul></li></ul></li><li><label\
-  \ class='ee-shut'>properties: Object (1 property)<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>foo:</span><span class='ee-v'>bar</span></li></ul></li></ul></li><li><label\
-  \ class='ee-shut'>3: Feature (0 properties)<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>type:</span><span class='ee-v'>Feature</span></li><li><span class='ee-k'>geometry:</span><span\
-  \ class='ee-v'>None</span></li><li><label class='ee-shut'>properties: Object (0\
-  \ properties)<input type='checkbox' class='ee-toggle'></label><ul></ul></li></ul></li><li><label\
-  \ class='ee-shut'>4: FeatureCollection (0 elements, 2 columns)<input type='checkbox'\
-  \ class='ee-toggle'></label><ul><li><span class='ee-k'>type:</span><span class='ee-v'>FeatureCollection</span></li><li><label\
-  \ class='ee-shut'>columns: Object (2 properties)<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>foo:</span><span class='ee-v'>String</span></li><li><span class='ee-k'>system:index:</span><span\
-  \ class='ee-v'>String</span></li></ul></li></ul></li><li><label class='ee-shut'>5:\
-  \ Date (2021-03-27 14:01:07)<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>type:</span><span class='ee-v'>Date</span></li><li><span class='ee-k'>value:</span><span\
-  \ class='ee-v'>1616853667000</span></li></ul></li><li><label class='ee-shut'>6:\
-  \ Filter.eq<input type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>type:</span><span\
+  \ class='ee-v'>int</span></li></ul></li></ul></li></ul></li></ul></li><li><label>1:\
+  \ ImageCollection (0 elements)<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span\
+  \ class='ee-v'>ImageCollection</span></li><li><label>bands: []<input type='checkbox'></label><ul></ul></li><li><label>properties:\
+  \ Object (1 property)<input type='checkbox'></label><ul><li><span class='ee-k'>test_prop:</span><span\
+  \ class='ee-v'>42</span></li></ul></li></ul></li><li><label>2: Feature (Point, 1\
+  \ property)<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span\
+  \ class='ee-v'>Feature</span></li><li><label>geometry: Point (0.00, 0.00)<input\
+  \ type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span class='ee-v'>Point</span></li><li><label>coordinates:\
+  \ [0, 0]<input type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span\
+  \ class='ee-v'>0</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>0</span></li></ul></li></ul></li><li><label>properties:\
+  \ Object (1 property)<input type='checkbox'></label><ul><li><span class='ee-k'>foo:</span><span\
+  \ class='ee-v'>bar</span></li></ul></li></ul></li><li><label>3: Feature (0 properties)<input\
+  \ type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span class='ee-v'>Feature</span></li><li><span\
+  \ class='ee-k'>geometry:</span><span class='ee-v'>None</span></li><li><label>properties:\
+  \ Object (0 properties)<input type='checkbox'></label><ul></ul></li></ul></li><li><label>4:\
+  \ FeatureCollection (0 elements, 2 columns)<input type='checkbox'></label><ul><li><span\
+  \ class='ee-k'>type:</span><span class='ee-v'>FeatureCollection</span></li><li><label>columns:\
+  \ Object (2 properties)<input type='checkbox'></label><ul><li><span class='ee-k'>foo:</span><span\
+  \ class='ee-v'>String</span></li><li><span class='ee-k'>system:index:</span><span\
+  \ class='ee-v'>String</span></li></ul></li></ul></li><li><label>5: Date (2021-03-27\
+  \ 14:01:07)<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span\
+  \ class='ee-v'>Date</span></li><li><span class='ee-k'>value:</span><span class='ee-v'>1616853667000</span></li></ul></li><li><label>6:\
+  \ Filter.eq<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span\
   \ class='ee-v'>Filter.eq</span></li><li><span class='ee-k'>leftField:</span><span\
-  \ class='ee-v'>foo</span></li><li><span class='ee-k'>rightValue:</span><span class='ee-v'>bar</span></li></ul></li><li><label\
-  \ class='ee-shut'>7: Object (1 property)<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>foo:</span><span class='ee-v'>bar</span></li></ul></li><li><label\
-  \ class='ee-shut'>8: [1, 2, 3, 4]<input type='checkbox' class='ee-toggle'></label><ul><li><span\
+  \ class='ee-v'>foo</span></li><li><span class='ee-k'>rightValue:</span><span class='ee-v'>bar</span></li></ul></li><li><label>7:\
+  \ Object (1 property)<input type='checkbox'></label><ul><li><span class='ee-k'>foo:</span><span\
+  \ class='ee-v'>bar</span></li></ul></li><li><label>8: [1, 2, 3, 4]<input type='checkbox'></label><ul><li><span\
   \ class='ee-k'>0:</span><span class='ee-v'>1</span></li><li><span class='ee-k'>1:</span><span\
   \ class='ee-v'>2</span></li><li><span class='ee-k'>2:</span><span class='ee-v'>3</span></li><li><span\
-  \ class='ee-k'>3:</span><span class='ee-v'>4</span></li></ul></li><li><label class='ee-shut'>9:\
-  \ List (21 elements)<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>0:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>1:</span><span\
-  \ class='ee-v'>1</span></li><li><span class='ee-k'>2:</span><span class='ee-v'>2</span></li><li><span\
-  \ class='ee-k'>3:</span><span class='ee-v'>3</span></li><li><span class='ee-k'>4:</span><span\
-  \ class='ee-v'>4</span></li><li><span class='ee-k'>5:</span><span class='ee-v'>5</span></li><li><span\
-  \ class='ee-k'>6:</span><span class='ee-v'>6</span></li><li><span class='ee-k'>7:</span><span\
-  \ class='ee-v'>7</span></li><li><span class='ee-k'>8:</span><span class='ee-v'>8</span></li><li><span\
-  \ class='ee-k'>9:</span><span class='ee-v'>9</span></li><li><span class='ee-k'>10:</span><span\
-  \ class='ee-v'>10</span></li><li><span class='ee-k'>11:</span><span class='ee-v'>11</span></li><li><span\
-  \ class='ee-k'>12:</span><span class='ee-v'>12</span></li><li><span class='ee-k'>13:</span><span\
-  \ class='ee-v'>13</span></li><li><span class='ee-k'>14:</span><span class='ee-v'>14</span></li><li><span\
-  \ class='ee-k'>15:</span><span class='ee-v'>15</span></li><li><span class='ee-k'>16:</span><span\
-  \ class='ee-v'>16</span></li><li><span class='ee-k'>17:</span><span class='ee-v'>17</span></li><li><span\
-  \ class='ee-k'>18:</span><span class='ee-v'>18</span></li><li><span class='ee-k'>19:</span><span\
-  \ class='ee-v'>19</span></li><li><span class='ee-k'>20:</span><span class='ee-v'>20</span></li></ul></li><li><span\
-  \ class='ee-k'>10:</span><span class='ee-v'>13th Warrior is an underrated movie</span></li><li><span\
-  \ class='ee-k'>11:</span><span class='ee-v'>42</span></li><li><label class='ee-shut'>12:\
-  \ Point (1.11, 2.00)<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>type:</span><span class='ee-v'>Point</span></li><li><label class='ee-shut'>coordinates:\
-  \ [1.112312, 2]<input type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>0:</span><span\
-  \ class='ee-v'>1.112312</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>2</span></li></ul></li></ul></li><li><label\
-  \ class='ee-shut'>13: MultiPoint (2 vertices)<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>type:</span><span class='ee-v'>MultiPoint</span></li><li><label class='ee-shut'>coordinates:\
-  \ [[1, 1], [2, 2]]<input type='checkbox' class='ee-toggle'></label><ul><li><label\
-  \ class='ee-shut'>0: [1, 1]<input type='checkbox' class='ee-toggle'></label><ul><li><span\
+  \ class='ee-k'>3:</span><span class='ee-v'>4</span></li></ul></li><li><label>9:\
+  \ List (21 elements)<input type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span\
+  \ class='ee-v'>0</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>1</span></li><li><span\
+  \ class='ee-k'>2:</span><span class='ee-v'>2</span></li><li><span class='ee-k'>3:</span><span\
+  \ class='ee-v'>3</span></li><li><span class='ee-k'>4:</span><span class='ee-v'>4</span></li><li><span\
+  \ class='ee-k'>5:</span><span class='ee-v'>5</span></li><li><span class='ee-k'>6:</span><span\
+  \ class='ee-v'>6</span></li><li><span class='ee-k'>7:</span><span class='ee-v'>7</span></li><li><span\
+  \ class='ee-k'>8:</span><span class='ee-v'>8</span></li><li><span class='ee-k'>9:</span><span\
+  \ class='ee-v'>9</span></li><li><span class='ee-k'>10:</span><span class='ee-v'>10</span></li><li><span\
+  \ class='ee-k'>11:</span><span class='ee-v'>11</span></li><li><span class='ee-k'>12:</span><span\
+  \ class='ee-v'>12</span></li><li><span class='ee-k'>13:</span><span class='ee-v'>13</span></li><li><span\
+  \ class='ee-k'>14:</span><span class='ee-v'>14</span></li><li><span class='ee-k'>15:</span><span\
+  \ class='ee-v'>15</span></li><li><span class='ee-k'>16:</span><span class='ee-v'>16</span></li><li><span\
+  \ class='ee-k'>17:</span><span class='ee-v'>17</span></li><li><span class='ee-k'>18:</span><span\
+  \ class='ee-v'>18</span></li><li><span class='ee-k'>19:</span><span class='ee-v'>19</span></li><li><span\
+  \ class='ee-k'>20:</span><span class='ee-v'>20</span></li></ul></li><li><span class='ee-k'>10:</span><span\
+  \ class='ee-v'>13th Warrior is an underrated movie</span></li><li><span class='ee-k'>11:</span><span\
+  \ class='ee-v'>42</span></li><li><label>12: Point (1.11, 2.00)<input type='checkbox'></label><ul><li><span\
+  \ class='ee-k'>type:</span><span class='ee-v'>Point</span></li><li><label>coordinates:\
+  \ [1.112312, 2]<input type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span\
+  \ class='ee-v'>1.112312</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>2</span></li></ul></li></ul></li><li><label>13:\
+  \ MultiPoint (2 vertices)<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span\
+  \ class='ee-v'>MultiPoint</span></li><li><label>coordinates: [[1, 1], [2, 2]]<input\
+  \ type='checkbox'></label><ul><li><label>0: [1, 1]<input type='checkbox'></label><ul><li><span\
   \ class='ee-k'>0:</span><span class='ee-v'>1</span></li><li><span class='ee-k'>1:</span><span\
-  \ class='ee-v'>1</span></li></ul></li><li><label class='ee-shut'>1: [2, 2]<input\
-  \ type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>0:</span><span\
-  \ class='ee-v'>2</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>2</span></li></ul></li></ul></li></ul></li><li><label\
-  \ class='ee-shut'>14: LineString (3 vertices)<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>type:</span><span class='ee-v'>LineString</span></li><li><label class='ee-shut'>coordinates:\
-  \ [[1, 1], [2, 2], [3, 3]]<input type='checkbox' class='ee-toggle'></label><ul><li><label\
-  \ class='ee-shut'>0: [1, 1]<input type='checkbox' class='ee-toggle'></label><ul><li><span\
+  \ class='ee-v'>1</span></li></ul></li><li><label>1: [2, 2]<input type='checkbox'></label><ul><li><span\
+  \ class='ee-k'>0:</span><span class='ee-v'>2</span></li><li><span class='ee-k'>1:</span><span\
+  \ class='ee-v'>2</span></li></ul></li></ul></li></ul></li><li><label>14: LineString\
+  \ (3 vertices)<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span\
+  \ class='ee-v'>LineString</span></li><li><label>coordinates: [[1, 1], [2, 2], [3,\
+  \ 3]]<input type='checkbox'></label><ul><li><label>0: [1, 1]<input type='checkbox'></label><ul><li><span\
   \ class='ee-k'>0:</span><span class='ee-v'>1</span></li><li><span class='ee-k'>1:</span><span\
-  \ class='ee-v'>1</span></li></ul></li><li><label class='ee-shut'>1: [2, 2]<input\
-  \ type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>0:</span><span\
-  \ class='ee-v'>2</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>2</span></li></ul></li><li><label\
-  \ class='ee-shut'>2: [3, 3]<input type='checkbox' class='ee-toggle'></label><ul><li><span\
+  \ class='ee-v'>1</span></li></ul></li><li><label>1: [2, 2]<input type='checkbox'></label><ul><li><span\
+  \ class='ee-k'>0:</span><span class='ee-v'>2</span></li><li><span class='ee-k'>1:</span><span\
+  \ class='ee-v'>2</span></li></ul></li><li><label>2: [3, 3]<input type='checkbox'></label><ul><li><span\
   \ class='ee-k'>0:</span><span class='ee-v'>3</span></li><li><span class='ee-k'>1:</span><span\
-  \ class='ee-v'>3</span></li></ul></li></ul></li></ul></li><li><label class='ee-shut'>15:\
-  \ MultiLineString<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>type:</span><span class='ee-v'>MultiLineString</span></li><li><label\
-  \ class='ee-shut'>coordinates: [[[0, 0], [1, 1]]]<input type='checkbox' class='ee-toggle'></label><ul><li><label\
-  \ class='ee-shut'>0: [[0, 0], [1, 1]]<input type='checkbox' class='ee-toggle'></label><ul><li><label\
-  \ class='ee-shut'>0: [0, 0]<input type='checkbox' class='ee-toggle'></label><ul><li><span\
+  \ class='ee-v'>3</span></li></ul></li></ul></li></ul></li><li><label>15: MultiLineString<input\
+  \ type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span class='ee-v'>MultiLineString</span></li><li><label>coordinates:\
+  \ [[[0, 0], [1, 1]]]<input type='checkbox'></label><ul><li><label>0: [[0, 0], [1,\
+  \ 1]]<input type='checkbox'></label><ul><li><label>0: [0, 0]<input type='checkbox'></label><ul><li><span\
   \ class='ee-k'>0:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>1:</span><span\
-  \ class='ee-v'>0</span></li></ul></li><li><label class='ee-shut'>1: [1, 1]<input\
-  \ type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>0:</span><span\
-  \ class='ee-v'>1</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>1</span></li></ul></li></ul></li></ul></li></ul></li><li><label\
-  \ class='ee-shut'>16: Polygon (4 vertices)<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>type:</span><span class='ee-v'>Polygon</span></li><li><label class='ee-shut'>coordinates:\
-  \ [[[0, 0], [1, 1], [2, 2], [0, 0]]]<input type='checkbox' class='ee-toggle'></label><ul><li><label\
-  \ class='ee-shut'>0: [[0, 0], [1, 1], [2, 2], [0, 0]]<input type='checkbox' class='ee-toggle'></label><ul><li><label\
-  \ class='ee-shut'>0: [0, 0]<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>0:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>1:</span><span\
-  \ class='ee-v'>0</span></li></ul></li><li><label class='ee-shut'>1: [1, 1]<input\
-  \ type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>0:</span><span\
-  \ class='ee-v'>1</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>1</span></li></ul></li><li><label\
-  \ class='ee-shut'>2: [2, 2]<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>0:</span><span class='ee-v'>2</span></li><li><span class='ee-k'>1:</span><span\
-  \ class='ee-v'>2</span></li></ul></li><li><label class='ee-shut'>3: [0, 0]<input\
-  \ type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>0:</span><span\
-  \ class='ee-v'>0</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>0</span></li></ul></li></ul></li></ul></li></ul></li><li><label\
-  \ class='ee-shut'>17: MultiPolygon (8 vertices)<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>type:</span><span class='ee-v'>MultiPolygon</span></li><li><label\
-  \ class='ee-shut'>coordinates: List (1 element)<input type='checkbox' class='ee-toggle'></label><ul><li><label\
-  \ class='ee-shut'>0: List (2 elements)<input type='checkbox' class='ee-toggle'></label><ul><li><label\
-  \ class='ee-shut'>0: [[0, 0], [1, 1], [2, 2], [0, 0]]<input type='checkbox' class='ee-toggle'></label><ul><li><label\
-  \ class='ee-shut'>0: [0, 0]<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>0:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>1:</span><span\
-  \ class='ee-v'>0</span></li></ul></li><li><label class='ee-shut'>1: [1, 1]<input\
-  \ type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>0:</span><span\
-  \ class='ee-v'>1</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>1</span></li></ul></li><li><label\
-  \ class='ee-shut'>2: [2, 2]<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>0:</span><span class='ee-v'>2</span></li><li><span class='ee-k'>1:</span><span\
-  \ class='ee-v'>2</span></li></ul></li><li><label class='ee-shut'>3: [0, 0]<input\
-  \ type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>0:</span><span\
-  \ class='ee-v'>0</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>0</span></li></ul></li></ul></li><li><label\
-  \ class='ee-shut'>1: [[4, 6], [3, 2], [1, 2], [4, 6]]<input type='checkbox' class='ee-toggle'></label><ul><li><label\
-  \ class='ee-shut'>0: [4, 6]<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>0:</span><span class='ee-v'>4</span></li><li><span class='ee-k'>1:</span><span\
-  \ class='ee-v'>6</span></li></ul></li><li><label class='ee-shut'>1: [3, 2]<input\
-  \ type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>0:</span><span\
-  \ class='ee-v'>3</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>2</span></li></ul></li><li><label\
-  \ class='ee-shut'>2: [1, 2]<input type='checkbox' class='ee-toggle'></label><ul><li><span\
+  \ class='ee-v'>0</span></li></ul></li><li><label>1: [1, 1]<input type='checkbox'></label><ul><li><span\
   \ class='ee-k'>0:</span><span class='ee-v'>1</span></li><li><span class='ee-k'>1:</span><span\
-  \ class='ee-v'>2</span></li></ul></li><li><label class='ee-shut'>3: [4, 6]<input\
-  \ type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>0:</span><span\
-  \ class='ee-v'>4</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>6</span></li></ul></li></ul></li></ul></li></ul></li></ul></li><li><label\
-  \ class='ee-shut'>18: LinearRing (4 vertices)<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>type:</span><span class='ee-v'>LinearRing</span></li><li><label class='ee-shut'>coordinates:\
-  \ [[0, 0], [1, 1], [2, 2], [0, 0]]<input type='checkbox' class='ee-toggle'></label><ul><li><label\
-  \ class='ee-shut'>0: [0, 0]<input type='checkbox' class='ee-toggle'></label><ul><li><span\
+  \ class='ee-v'>1</span></li></ul></li></ul></li></ul></li></ul></li><li><label>16:\
+  \ Polygon (4 vertices)<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span\
+  \ class='ee-v'>Polygon</span></li><li><label>coordinates: [[[0, 0], [1, 1], [2,\
+  \ 2], [0, 0]]]<input type='checkbox'></label><ul><li><label>0: [[0, 0], [1, 1],\
+  \ [2, 2], [0, 0]]<input type='checkbox'></label><ul><li><label>0: [0, 0]<input type='checkbox'></label><ul><li><span\
   \ class='ee-k'>0:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>1:</span><span\
-  \ class='ee-v'>0</span></li></ul></li><li><label class='ee-shut'>1: [1, 1]<input\
-  \ type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>0:</span><span\
-  \ class='ee-v'>1</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>1</span></li></ul></li><li><label\
-  \ class='ee-shut'>2: [2, 2]<input type='checkbox' class='ee-toggle'></label><ul><li><span\
+  \ class='ee-v'>0</span></li></ul></li><li><label>1: [1, 1]<input type='checkbox'></label><ul><li><span\
+  \ class='ee-k'>0:</span><span class='ee-v'>1</span></li><li><span class='ee-k'>1:</span><span\
+  \ class='ee-v'>1</span></li></ul></li><li><label>2: [2, 2]<input type='checkbox'></label><ul><li><span\
   \ class='ee-k'>0:</span><span class='ee-v'>2</span></li><li><span class='ee-k'>1:</span><span\
-  \ class='ee-v'>2</span></li></ul></li><li><label class='ee-shut'>3: [0, 0]<input\
-  \ type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>0:</span><span\
-  \ class='ee-v'>0</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>0</span></li></ul></li></ul></li></ul></li><li><label\
-  \ class='ee-shut'>19: DateRange [2020-01-01 21:01:10, 2022-03-01 14:32:11]<input\
-  \ type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>type:</span><span\
-  \ class='ee-v'>DateRange</span></li><li><label class='ee-shut'>dates: [1577912470000,\
-  \ 1646145131000]<input type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>0:</span><span\
-  \ class='ee-v'>1577912470000</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>1646145131000</span></li></ul></li></ul></li><li><label\
-  \ class='ee-shut'>20: Foo bar <input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>type:</span><span class='ee-v'>Foo</span></li><li><span class='ee-k'>id:</span><span\
-  \ class='ee-v'>bar</span></li></ul></li><li><label class='ee-shut'>21: \"B1\", unsigned\
-  \ int16, EPSG:32610, 1830x1830 px<input type='checkbox' class='ee-toggle'></label><ul><li><span\
+  \ class='ee-v'>2</span></li></ul></li><li><label>3: [0, 0]<input type='checkbox'></label><ul><li><span\
+  \ class='ee-k'>0:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>1:</span><span\
+  \ class='ee-v'>0</span></li></ul></li></ul></li></ul></li></ul></li><li><label>17:\
+  \ MultiPolygon (8 vertices)<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span\
+  \ class='ee-v'>MultiPolygon</span></li><li><label>coordinates: List (1 element)<input\
+  \ type='checkbox'></label><ul><li><label>0: List (2 elements)<input type='checkbox'></label><ul><li><label>0:\
+  \ [[0, 0], [1, 1], [2, 2], [0, 0]]<input type='checkbox'></label><ul><li><label>0:\
+  \ [0, 0]<input type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span\
+  \ class='ee-v'>0</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>0</span></li></ul></li><li><label>1:\
+  \ [1, 1]<input type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span\
+  \ class='ee-v'>1</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>1</span></li></ul></li><li><label>2:\
+  \ [2, 2]<input type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span\
+  \ class='ee-v'>2</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>2</span></li></ul></li><li><label>3:\
+  \ [0, 0]<input type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span\
+  \ class='ee-v'>0</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>0</span></li></ul></li></ul></li><li><label>1:\
+  \ [[4, 6], [3, 2], [1, 2], [4, 6]]<input type='checkbox'></label><ul><li><label>0:\
+  \ [4, 6]<input type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span\
+  \ class='ee-v'>4</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>6</span></li></ul></li><li><label>1:\
+  \ [3, 2]<input type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span\
+  \ class='ee-v'>3</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>2</span></li></ul></li><li><label>2:\
+  \ [1, 2]<input type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span\
+  \ class='ee-v'>1</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>2</span></li></ul></li><li><label>3:\
+  \ [4, 6]<input type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span\
+  \ class='ee-v'>4</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>6</span></li></ul></li></ul></li></ul></li></ul></li></ul></li><li><label>18:\
+  \ LinearRing (4 vertices)<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span\
+  \ class='ee-v'>LinearRing</span></li><li><label>coordinates: [[0, 0], [1, 1], [2,\
+  \ 2], [0, 0]]<input type='checkbox'></label><ul><li><label>0: [0, 0]<input type='checkbox'></label><ul><li><span\
+  \ class='ee-k'>0:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>1:</span><span\
+  \ class='ee-v'>0</span></li></ul></li><li><label>1: [1, 1]<input type='checkbox'></label><ul><li><span\
+  \ class='ee-k'>0:</span><span class='ee-v'>1</span></li><li><span class='ee-k'>1:</span><span\
+  \ class='ee-v'>1</span></li></ul></li><li><label>2: [2, 2]<input type='checkbox'></label><ul><li><span\
+  \ class='ee-k'>0:</span><span class='ee-v'>2</span></li><li><span class='ee-k'>1:</span><span\
+  \ class='ee-v'>2</span></li></ul></li><li><label>3: [0, 0]<input type='checkbox'></label><ul><li><span\
+  \ class='ee-k'>0:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>1:</span><span\
+  \ class='ee-v'>0</span></li></ul></li></ul></li></ul></li><li><label>19: DateRange\
+  \ [2020-01-01 21:01:10, 2022-03-01 14:32:11]<input type='checkbox'></label><ul><li><span\
+  \ class='ee-k'>type:</span><span class='ee-v'>DateRange</span></li><li><label>dates:\
+  \ [1577912470000, 1646145131000]<input type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span\
+  \ class='ee-v'>1577912470000</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>1646145131000</span></li></ul></li></ul></li><li><label>20:\
+  \ Foo bar <input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span\
+  \ class='ee-v'>Foo</span></li><li><span class='ee-k'>id:</span><span class='ee-v'>bar</span></li></ul></li><li><label>21:\
+  \ \"B1\", unsigned int16, EPSG:32610, 1830x1830 px<input type='checkbox'></label><ul><li><span\
   \ class='ee-k'>id:</span><span class='ee-v'>B1</span></li><li><span class='ee-k'>crs:</span><span\
-  \ class='ee-v'>EPSG:32610</span></li><li><label class='ee-shut'>data_type: unsigned\
-  \ int16<input type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>type:</span><span\
-  \ class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span class='ee-v'>65535</span></li><li><span\
-  \ class='ee-k'>min:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>precision:</span><span\
-  \ class='ee-v'>int</span></li></ul></li><li><label class='ee-shut'>dimensions: [1830,\
-  \ 1830]<input type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>0:</span><span\
-  \ class='ee-v'>1830</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>1830</span></li></ul></li></ul></li><li><label\
-  \ class='ee-shut'>22: \"B1\", unsigned int16<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>id:</span><span class='ee-v'>B1</span></li><li><label class='ee-shut'>data_type:\
-  \ unsigned int16<input type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>type:</span><span\
-  \ class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span class='ee-v'>65535</span></li><li><span\
-  \ class='ee-k'>min:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>precision:</span><span\
-  \ class='ee-v'>int</span></li></ul></li></ul></li><li><label class='ee-shut'>23:\
-  \ float<input type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>type:</span><span\
+  \ class='ee-v'>EPSG:32610</span></li><li><label>data_type: unsigned int16<input\
+  \ type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span class='ee-v'>PixelType</span></li><li><span\
+  \ class='ee-k'>max:</span><span class='ee-v'>65535</span></li><li><span class='ee-k'>min:</span><span\
+  \ class='ee-v'>0</span></li><li><span class='ee-k'>precision:</span><span class='ee-v'>int</span></li></ul></li><li><label>dimensions:\
+  \ [1830, 1830]<input type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span\
+  \ class='ee-v'>1830</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>1830</span></li></ul></li></ul></li><li><label>22:\
+  \ \"B1\", unsigned int16<input type='checkbox'></label><ul><li><span class='ee-k'>id:</span><span\
+  \ class='ee-v'>B1</span></li><li><label>data_type: unsigned int16<input type='checkbox'></label><ul><li><span\
+  \ class='ee-k'>type:</span><span class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span\
+  \ class='ee-v'>65535</span></li><li><span class='ee-k'>min:</span><span class='ee-v'>0</span></li><li><span\
+  \ class='ee-k'>precision:</span><span class='ee-v'>int</span></li></ul></li></ul></li><li><label>23:\
+  \ float<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span\
   \ class='ee-v'>PixelType</span></li><li><span class='ee-k'>precision:</span><span\
-  \ class='ee-v'>float</span></li></ul></li><li><label class='ee-shut'>24: double<input\
-  \ type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>type:</span><span\
-  \ class='ee-v'>PixelType</span></li><li><span class='ee-k'>precision:</span><span\
-  \ class='ee-v'>double</span></li></ul></li><li><label class='ee-shut'>25: signed\
-  \ int8<input type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>type:</span><span\
-  \ class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span class='ee-v'>127</span></li><li><span\
-  \ class='ee-k'>min:</span><span class='ee-v'>-128</span></li><li><span class='ee-k'>precision:</span><span\
-  \ class='ee-v'>int</span></li></ul></li><li><label class='ee-shut'>26: unsigned\
-  \ int8<input type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>type:</span><span\
+  \ class='ee-v'>float</span></li></ul></li><li><label>24: double<input type='checkbox'></label><ul><li><span\
+  \ class='ee-k'>type:</span><span class='ee-v'>PixelType</span></li><li><span class='ee-k'>precision:</span><span\
+  \ class='ee-v'>double</span></li></ul></li><li><label>25: signed int8<input type='checkbox'></label><ul><li><span\
+  \ class='ee-k'>type:</span><span class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span\
+  \ class='ee-v'>127</span></li><li><span class='ee-k'>min:</span><span class='ee-v'>-128</span></li><li><span\
+  \ class='ee-k'>precision:</span><span class='ee-v'>int</span></li></ul></li><li><label>26:\
+  \ unsigned int8<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span\
   \ class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span class='ee-v'>255</span></li><li><span\
   \ class='ee-k'>min:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>precision:</span><span\
-  \ class='ee-v'>int</span></li></ul></li><li><label class='ee-shut'>27: signed int16<input\
-  \ type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>type:</span><span\
-  \ class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span class='ee-v'>32767</span></li><li><span\
-  \ class='ee-k'>min:</span><span class='ee-v'>-32768</span></li><li><span class='ee-k'>precision:</span><span\
-  \ class='ee-v'>int</span></li></ul></li><li><label class='ee-shut'>28: unsigned\
-  \ int16<input type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>type:</span><span\
+  \ class='ee-v'>int</span></li></ul></li><li><label>27: signed int16<input type='checkbox'></label><ul><li><span\
+  \ class='ee-k'>type:</span><span class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span\
+  \ class='ee-v'>32767</span></li><li><span class='ee-k'>min:</span><span class='ee-v'>-32768</span></li><li><span\
+  \ class='ee-k'>precision:</span><span class='ee-v'>int</span></li></ul></li><li><label>28:\
+  \ unsigned int16<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span\
   \ class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span class='ee-v'>65535</span></li><li><span\
   \ class='ee-k'>min:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>precision:</span><span\
-  \ class='ee-v'>int</span></li></ul></li><li><label class='ee-shut'>29: signed int32<input\
-  \ type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>type:</span><span\
-  \ class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span class='ee-v'>2147483647</span></li><li><span\
-  \ class='ee-k'>min:</span><span class='ee-v'>-2147483648</span></li><li><span class='ee-k'>precision:</span><span\
-  \ class='ee-v'>int</span></li></ul></li><li><label class='ee-shut'>30: unsigned\
-  \ int32<input type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>type:</span><span\
+  \ class='ee-v'>int</span></li></ul></li><li><label>29: signed int32<input type='checkbox'></label><ul><li><span\
+  \ class='ee-k'>type:</span><span class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span\
+  \ class='ee-v'>2147483647</span></li><li><span class='ee-k'>min:</span><span class='ee-v'>-2147483648</span></li><li><span\
+  \ class='ee-k'>precision:</span><span class='ee-v'>int</span></li></ul></li><li><label>30:\
+  \ unsigned int32<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span\
   \ class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span class='ee-v'>4294967295</span></li><li><span\
   \ class='ee-k'>min:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>precision:</span><span\
-  \ class='ee-v'>int</span></li></ul></li><li><label class='ee-shut'>31: signed int64<input\
-  \ type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>type:</span><span\
-  \ class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span class='ee-v'>9.223372036854776e+18</span></li><li><span\
-  \ class='ee-k'>min:</span><span class='ee-v'>-9.223372036854776e+18</span></li><li><span\
-  \ class='ee-k'>precision:</span><span class='ee-v'>int</span></li></ul></li><li><label\
-  \ class='ee-shut'>32: int ∈ [10, 255]<input type='checkbox' class='ee-toggle'></label><ul><li><span\
+  \ class='ee-v'>int</span></li></ul></li><li><label>31: signed int64<input type='checkbox'></label><ul><li><span\
+  \ class='ee-k'>type:</span><span class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span\
+  \ class='ee-v'>9.223372036854776e+18</span></li><li><span class='ee-k'>min:</span><span\
+  \ class='ee-v'>-9.223372036854776e+18</span></li><li><span class='ee-k'>precision:</span><span\
+  \ class='ee-v'>int</span></li></ul></li><li><label>32: int ∈ [10, 255]<input type='checkbox'></label><ul><li><span\
   \ class='ee-k'>type:</span><span class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span\
   \ class='ee-v'>255</span></li><li><span class='ee-k'>min:</span><span class='ee-v'>10</span></li><li><span\
-  \ class='ee-k'>precision:</span><span class='ee-v'>int</span></li></ul></li><li><label\
-  \ class='ee-shut'>33: Clusterer.wekaKMeans<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>type:</span><span class='ee-v'>Clusterer.wekaKMeans</span></li><li><span\
-  \ class='ee-k'>nClusters:</span><span class='ee-v'>2</span></li></ul></li><li><label\
-  \ class='ee-shut'>34: Classifier.smileKNN<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>type:</span><span class='ee-v'>Classifier.smileKNN</span></li></ul></li><li><label\
-  \ class='ee-shut'>35: [[1, 2], [3, 4]]<input type='checkbox' class='ee-toggle'></label><ul><li><label\
-  \ class='ee-shut'>0: [1, 2]<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>0:</span><span class='ee-v'>1</span></li><li><span class='ee-k'>1:</span><span\
-  \ class='ee-v'>2</span></li></ul></li><li><label class='ee-shut'>1: [3, 4]<input\
-  \ type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>0:</span><span\
-  \ class='ee-v'>3</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>4</span></li></ul></li></ul></li><li><label\
-  \ class='ee-shut'>36: [[1, 2], [3, 4]]<input type='checkbox' class='ee-toggle'></label><ul><li><label\
-  \ class='ee-shut'>0: [1, 2]<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>0:</span><span class='ee-v'>1</span></li><li><span class='ee-k'>1:</span><span\
-  \ class='ee-v'>2</span></li></ul></li><li><label class='ee-shut'>1: [3, 4]<input\
-  \ type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>0:</span><span\
-  \ class='ee-v'>3</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>4</span></li></ul></li></ul></li><li><label\
-  \ class='ee-shut'>37: Kernel.gaussian<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>type:</span><span class='ee-v'>Kernel.gaussian</span></li><li><label\
-  \ class='ee-shut'>center: [3, 3]<input type='checkbox' class='ee-toggle'></label><ul><li><span\
+  \ class='ee-k'>precision:</span><span class='ee-v'>int</span></li></ul></li><li><label>33:\
+  \ Clusterer.wekaKMeans<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span\
+  \ class='ee-v'>Clusterer.wekaKMeans</span></li><li><span class='ee-k'>nClusters:</span><span\
+  \ class='ee-v'>2</span></li></ul></li><li><label>34: Classifier.smileKNN<input type='checkbox'></label><ul><li><span\
+  \ class='ee-k'>type:</span><span class='ee-v'>Classifier.smileKNN</span></li></ul></li><li><label>35:\
+  \ [[1, 2], [3, 4]]<input type='checkbox'></label><ul><li><label>0: [1, 2]<input\
+  \ type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span class='ee-v'>1</span></li><li><span\
+  \ class='ee-k'>1:</span><span class='ee-v'>2</span></li></ul></li><li><label>1:\
+  \ [3, 4]<input type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span\
+  \ class='ee-v'>3</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>4</span></li></ul></li></ul></li><li><label>36:\
+  \ [[1, 2], [3, 4]]<input type='checkbox'></label><ul><li><label>0: [1, 2]<input\
+  \ type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span class='ee-v'>1</span></li><li><span\
+  \ class='ee-k'>1:</span><span class='ee-v'>2</span></li></ul></li><li><label>1:\
+  \ [3, 4]<input type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span\
+  \ class='ee-v'>3</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>4</span></li></ul></li></ul></li><li><label>37:\
+  \ Kernel.gaussian<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span\
+  \ class='ee-v'>Kernel.gaussian</span></li><li><label>center: [3, 3]<input type='checkbox'></label><ul><li><span\
   \ class='ee-k'>0:</span><span class='ee-v'>3</span></li><li><span class='ee-k'>1:</span><span\
   \ class='ee-v'>3</span></li></ul></li><li><span class='ee-k'>radius:</span><span\
   \ class='ee-v'>3</span></li><li><span class='ee-k'>weights:</span><span class='ee-v'>\n\
@@ -270,17 +234,13 @@
   \ 0.0029166029543864387, 0.013071307583189414, 0.02155094284826827, 0.013071307583189414,\
   \ 0.0029166029543864387, 2.3940934949727E-4]\n  [1.9651916124031917E-5, 2.3940934949727E-4,\
   \ 0.001072958264978661, 0.0017690091140438226, 0.001072958264978661, 2.3940934949727E-4,\
-  \ 1.9651916124031917E-5]</span></li></ul></li><li><label class='ee-shut'>38: Projection<input\
-  \ type='checkbox' class='ee-toggle'></label><ul><li><span class='ee-k'>type:</span><span\
-  \ class='ee-v'>Projection</span></li><li><span class='ee-k'>crs:</span><span class='ee-v'>EPSG:5070</span></li><li><label\
-  \ class='ee-shut'>transform: [100, 0, 0, 0, 100, 0]<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>0:</span><span class='ee-v'>100</span></li><li><span class='ee-k'>1:</span><span\
-  \ class='ee-v'>0</span></li><li><span class='ee-k'>2:</span><span class='ee-v'>0</span></li><li><span\
-  \ class='ee-k'>3:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>4:</span><span\
-  \ class='ee-v'>100</span></li><li><span class='ee-k'>5:</span><span class='ee-v'>0</span></li></ul></li></ul></li><li><label\
-  \ class='ee-shut'>39: Reducer.max<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>type:</span><span class='ee-v'>Reducer.max</span></li><li><span class='ee-k'>numInputs:</span><span\
-  \ class='ee-v'>5</span></li></ul></li></ul></li></ul></div><script>function toggleHeader()\
-  \ {\n    const parent = this.parentElement;\n    parent.className = parent.className\
-  \ === \"ee-open\" ? \"ee-shut\" : \"ee-open\";\n}\n\nfor (let c of document.getElementsByClassName(\"\
-  ee-toggle\")) {\n    c.onclick = toggleHeader;\n}</script></div>"
+  \ 1.9651916124031917E-5]</span></li></ul></li><li><label>38: Projection<input type='checkbox'></label><ul><li><span\
+  \ class='ee-k'>type:</span><span class='ee-v'>Projection</span></li><li><span class='ee-k'>crs:</span><span\
+  \ class='ee-v'>EPSG:5070</span></li><li><label>transform: [100, 0, 0, 0, 100, 0]<input\
+  \ type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span class='ee-v'>100</span></li><li><span\
+  \ class='ee-k'>1:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>2:</span><span\
+  \ class='ee-v'>0</span></li><li><span class='ee-k'>3:</span><span class='ee-v'>0</span></li><li><span\
+  \ class='ee-k'>4:</span><span class='ee-v'>100</span></li><li><span class='ee-k'>5:</span><span\
+  \ class='ee-v'>0</span></li></ul></li></ul></li><li><label>39: Reducer.max<input\
+  \ type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span class='ee-v'>Reducer.max</span></li><li><span\
+  \ class='ee-k'>numInputs:</span><span class='ee-v'>5</span></li></ul></li></ul></li></ul></div></div>"

--- a/tests/data/test_regression_objects_array_.yml
+++ b/tests/data/test_regression_objects_array_.yml
@@ -1,6 +1,5 @@
-'<li><label class=''ee-shut''>[[1, 2], [3, 4]]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><label
-  class=''ee-shut''>0: [1, 2]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>0:</span><span class=''ee-v''>1</span></li><li><span class=''ee-k''>1:</span><span
-  class=''ee-v''>2</span></li></ul></li><li><label class=''ee-shut''>1: [3, 4]<input
-  type=''checkbox'' class=''ee-toggle''></label><ul><li><span class=''ee-k''>0:</span><span
+'<li><label>[[1, 2], [3, 4]]<input type=''checkbox''></label><ul><li><label>0: [1,
+  2]<input type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span class=''ee-v''>1</span></li><li><span
+  class=''ee-k''>1:</span><span class=''ee-v''>2</span></li></ul></li><li><label>1:
+  [3, 4]<input type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span
   class=''ee-v''>3</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>4</span></li></ul></li></ul></li>'

--- a/tests/data/test_regression_objects_band_dict_.yml
+++ b/tests/data/test_regression_objects_band_dict_.yml
@@ -1,10 +1,8 @@
-'<li><label class=''ee-shut''>"B1", unsigned int16, EPSG:32610, 1830x1830 px<input
-  type=''checkbox'' class=''ee-toggle''></label><ul><li><span class=''ee-k''>id:</span><span
-  class=''ee-v''>B1</span></li><li><span class=''ee-k''>crs:</span><span class=''ee-v''>EPSG:32610</span></li><li><label
-  class=''ee-shut''>data_type: unsigned int16<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>type:</span><span class=''ee-v''>PixelType</span></li><li><span class=''ee-k''>max:</span><span
-  class=''ee-v''>65535</span></li><li><span class=''ee-k''>min:</span><span class=''ee-v''>0</span></li><li><span
-  class=''ee-k''>precision:</span><span class=''ee-v''>int</span></li></ul></li><li><label
-  class=''ee-shut''>dimensions: [1830, 1830]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>0:</span><span class=''ee-v''>1830</span></li><li><span class=''ee-k''>1:</span><span
-  class=''ee-v''>1830</span></li></ul></li></ul></li>'
+'<li><label>"B1", unsigned int16, EPSG:32610, 1830x1830 px<input type=''checkbox''></label><ul><li><span
+  class=''ee-k''>id:</span><span class=''ee-v''>B1</span></li><li><span class=''ee-k''>crs:</span><span
+  class=''ee-v''>EPSG:32610</span></li><li><label>data_type: unsigned int16<input
+  type=''checkbox''></label><ul><li><span class=''ee-k''>type:</span><span class=''ee-v''>PixelType</span></li><li><span
+  class=''ee-k''>max:</span><span class=''ee-v''>65535</span></li><li><span class=''ee-k''>min:</span><span
+  class=''ee-v''>0</span></li><li><span class=''ee-k''>precision:</span><span class=''ee-v''>int</span></li></ul></li><li><label>dimensions:
+  [1830, 1830]<input type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span
+  class=''ee-v''>1830</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>1830</span></li></ul></li></ul></li>'

--- a/tests/data/test_regression_objects_classifier_.yml
+++ b/tests/data/test_regression_objects_classifier_.yml
@@ -1,3 +1,3 @@
-<li><label class='ee-shut'>Classifier.smileKNN<input type='checkbox' class='ee-toggle'></label><ul><li><span
-  class='ee-k'>type:</span><span class='ee-v'>Classifier.smileKNN</span></li></ul></li>
+<li><label>Classifier.smileKNN<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span
+  class='ee-v'>Classifier.smileKNN</span></li></ul></li>
 ...

--- a/tests/data/test_regression_objects_clusterer_.yml
+++ b/tests/data/test_regression_objects_clusterer_.yml
@@ -1,4 +1,4 @@
-<li><label class='ee-shut'>Clusterer.wekaKMeans<input type='checkbox' class='ee-toggle'></label><ul><li><span
-  class='ee-k'>type:</span><span class='ee-v'>Clusterer.wekaKMeans</span></li><li><span
-  class='ee-k'>nClusters:</span><span class='ee-v'>2</span></li></ul></li>
+<li><label>Clusterer.wekaKMeans<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span
+  class='ee-v'>Clusterer.wekaKMeans</span></li><li><span class='ee-k'>nClusters:</span><span
+  class='ee-v'>2</span></li></ul></li>
 ...

--- a/tests/data/test_regression_objects_confusion_matrix_.yml
+++ b/tests/data/test_regression_objects_confusion_matrix_.yml
@@ -1,6 +1,5 @@
-'<li><label class=''ee-shut''>[[1, 2], [3, 4]]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><label
-  class=''ee-shut''>0: [1, 2]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>0:</span><span class=''ee-v''>1</span></li><li><span class=''ee-k''>1:</span><span
-  class=''ee-v''>2</span></li></ul></li><li><label class=''ee-shut''>1: [3, 4]<input
-  type=''checkbox'' class=''ee-toggle''></label><ul><li><span class=''ee-k''>0:</span><span
+'<li><label>[[1, 2], [3, 4]]<input type=''checkbox''></label><ul><li><label>0: [1,
+  2]<input type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span class=''ee-v''>1</span></li><li><span
+  class=''ee-k''>1:</span><span class=''ee-v''>2</span></li></ul></li><li><label>1:
+  [3, 4]<input type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span
   class=''ee-v''>3</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>4</span></li></ul></li></ul></li>'

--- a/tests/data/test_regression_objects_constant_image_.yml
+++ b/tests/data/test_regression_objects_constant_image_.yml
@@ -1,16 +1,14 @@
-'<li><label class=''ee-shut''>Image foo (1 band)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>type:</span><span class=''ee-v''>Image</span></li><li><span class=''ee-k''>id:</span><span
-  class=''ee-v''>foo</span></li><li><label class=''ee-shut''>bands: List (1 element)<input
-  type=''checkbox'' class=''ee-toggle''></label><ul><li><label class=''ee-shut''>0:
-  "constant", int ∈ [0, 0], EPSG:4326<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>id:</span><span class=''ee-v''>constant</span></li><li><span class=''ee-k''>crs:</span><span
-  class=''ee-v''>EPSG:4326</span></li><li><label class=''ee-shut''>crs_transform:
-  [1, 0, 0, 0, 1, 0]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>0:</span><span class=''ee-v''>1</span></li><li><span class=''ee-k''>1:</span><span
-  class=''ee-v''>0</span></li><li><span class=''ee-k''>2:</span><span class=''ee-v''>0</span></li><li><span
-  class=''ee-k''>3:</span><span class=''ee-v''>0</span></li><li><span class=''ee-k''>4:</span><span
-  class=''ee-v''>1</span></li><li><span class=''ee-k''>5:</span><span class=''ee-v''>0</span></li></ul></li><li><label
-  class=''ee-shut''>data_type: int ∈ [0, 0]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>type:</span><span class=''ee-v''>PixelType</span></li><li><span class=''ee-k''>max:</span><span
-  class=''ee-v''>0</span></li><li><span class=''ee-k''>min:</span><span class=''ee-v''>0</span></li><li><span
-  class=''ee-k''>precision:</span><span class=''ee-v''>int</span></li></ul></li></ul></li></ul></li></ul></li>'
+'<li><label>Image foo (1 band)<input type=''checkbox''></label><ul><li><span class=''ee-k''>type:</span><span
+  class=''ee-v''>Image</span></li><li><span class=''ee-k''>id:</span><span class=''ee-v''>foo</span></li><li><label>bands:
+  List (1 element)<input type=''checkbox''></label><ul><li><label>0: "constant", int
+  ∈ [0, 0], EPSG:4326<input type=''checkbox''></label><ul><li><span class=''ee-k''>id:</span><span
+  class=''ee-v''>constant</span></li><li><span class=''ee-k''>crs:</span><span class=''ee-v''>EPSG:4326</span></li><li><label>crs_transform:
+  [1, 0, 0, 0, 1, 0]<input type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span
+  class=''ee-v''>1</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>0</span></li><li><span
+  class=''ee-k''>2:</span><span class=''ee-v''>0</span></li><li><span class=''ee-k''>3:</span><span
+  class=''ee-v''>0</span></li><li><span class=''ee-k''>4:</span><span class=''ee-v''>1</span></li><li><span
+  class=''ee-k''>5:</span><span class=''ee-v''>0</span></li></ul></li><li><label>data_type:
+  int ∈ [0, 0]<input type=''checkbox''></label><ul><li><span class=''ee-k''>type:</span><span
+  class=''ee-v''>PixelType</span></li><li><span class=''ee-k''>max:</span><span class=''ee-v''>0</span></li><li><span
+  class=''ee-k''>min:</span><span class=''ee-v''>0</span></li><li><span class=''ee-k''>precision:</span><span
+  class=''ee-v''>int</span></li></ul></li></ul></li></ul></li></ul></li>'

--- a/tests/data/test_regression_objects_date_.yml
+++ b/tests/data/test_regression_objects_date_.yml
@@ -1,4 +1,4 @@
-<li><label class='ee-shut'>Date (2021-03-27 14:01:07)<input type='checkbox' class='ee-toggle'></label><ul><li><span
+<li><label>Date (2021-03-27 14:01:07)<input type='checkbox'></label><ul><li><span
   class='ee-k'>type:</span><span class='ee-v'>Date</span></li><li><span class='ee-k'>value:</span><span
   class='ee-v'>1616853667000</span></li></ul></li>
 ...

--- a/tests/data/test_regression_objects_daterange_.yml
+++ b/tests/data/test_regression_objects_daterange_.yml
@@ -1,6 +1,5 @@
-'<li><label class=''ee-shut''>DateRange [2020-01-01 21:01:10, 2022-03-01 14:32:11]<input
-  type=''checkbox'' class=''ee-toggle''></label><ul><li><span class=''ee-k''>type:</span><span
-  class=''ee-v''>DateRange</span></li><li><label class=''ee-shut''>dates: [1577912470000,
-  1646145131000]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>0:</span><span class=''ee-v''>1577912470000</span></li><li><span
-  class=''ee-k''>1:</span><span class=''ee-v''>1646145131000</span></li></ul></li></ul></li>'
+'<li><label>DateRange [2020-01-01 21:01:10, 2022-03-01 14:32:11]<input type=''checkbox''></label><ul><li><span
+  class=''ee-k''>type:</span><span class=''ee-v''>DateRange</span></li><li><label>dates:
+  [1577912470000, 1646145131000]<input type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span
+  class=''ee-v''>1577912470000</span></li><li><span class=''ee-k''>1:</span><span
+  class=''ee-v''>1646145131000</span></li></ul></li></ul></li>'

--- a/tests/data/test_regression_objects_dict_.yml
+++ b/tests/data/test_regression_objects_dict_.yml
@@ -1,3 +1,3 @@
-<li><label class='ee-shut'>Object (1 property)<input type='checkbox' class='ee-toggle'></label><ul><li><span
-  class='ee-k'>foo:</span><span class='ee-v'>bar</span></li></ul></li>
+<li><label>Object (1 property)<input type='checkbox'></label><ul><li><span class='ee-k'>foo:</span><span
+  class='ee-v'>bar</span></li></ul></li>
 ...

--- a/tests/data/test_regression_objects_feature_.yml
+++ b/tests/data/test_regression_objects_feature_.yml
@@ -1,8 +1,8 @@
-'<li><label class=''ee-shut''>Feature (Point, 1 property)<input type=''checkbox''
-  class=''ee-toggle''></label><ul><li><span class=''ee-k''>type:</span><span class=''ee-v''>Feature</span></li><li><label
-  class=''ee-shut''>geometry: Point (0.00, 0.00)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>type:</span><span class=''ee-v''>Point</span></li><li><label class=''ee-shut''>coordinates:
-  [0, 0]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span class=''ee-k''>0:</span><span
-  class=''ee-v''>0</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>0</span></li></ul></li></ul></li><li><label
-  class=''ee-shut''>properties: Object (1 property)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>foo:</span><span class=''ee-v''>bar</span></li></ul></li></ul></li>'
+'<li><label>Feature (Point, 1 property)<input type=''checkbox''></label><ul><li><span
+  class=''ee-k''>type:</span><span class=''ee-v''>Feature</span></li><li><label>geometry:
+  Point (0.00, 0.00)<input type=''checkbox''></label><ul><li><span class=''ee-k''>type:</span><span
+  class=''ee-v''>Point</span></li><li><label>coordinates: [0, 0]<input type=''checkbox''></label><ul><li><span
+  class=''ee-k''>0:</span><span class=''ee-v''>0</span></li><li><span class=''ee-k''>1:</span><span
+  class=''ee-v''>0</span></li></ul></li></ul></li><li><label>properties: Object (1
+  property)<input type=''checkbox''></label><ul><li><span class=''ee-k''>foo:</span><span
+  class=''ee-v''>bar</span></li></ul></li></ul></li>'

--- a/tests/data/test_regression_objects_feature_collection_.yml
+++ b/tests/data/test_regression_objects_feature_collection_.yml
@@ -1,15 +1,13 @@
-'<li><label class=''ee-shut''>FeatureCollection (1 element, 2 columns)<input type=''checkbox''
-  class=''ee-toggle''></label><ul><li><span class=''ee-k''>type:</span><span class=''ee-v''>FeatureCollection</span></li><li><label
-  class=''ee-shut''>columns: Object (2 properties)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>foo:</span><span class=''ee-v''>String</span></li><li><span class=''ee-k''>system:index:</span><span
-  class=''ee-v''>String</span></li></ul></li><li><label class=''ee-shut''>features:
-  List (1 element)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><label
-  class=''ee-shut''>0: Feature (Point, 1 property)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
+'<li><label>FeatureCollection (1 element, 2 columns)<input type=''checkbox''></label><ul><li><span
+  class=''ee-k''>type:</span><span class=''ee-v''>FeatureCollection</span></li><li><label>columns:
+  Object (2 properties)<input type=''checkbox''></label><ul><li><span class=''ee-k''>foo:</span><span
+  class=''ee-v''>String</span></li><li><span class=''ee-k''>system:index:</span><span
+  class=''ee-v''>String</span></li></ul></li><li><label>features: List (1 element)<input
+  type=''checkbox''></label><ul><li><label>0: Feature (Point, 1 property)<input type=''checkbox''></label><ul><li><span
   class=''ee-k''>type:</span><span class=''ee-v''>Feature</span></li><li><span class=''ee-k''>id:</span><span
-  class=''ee-v''>0</span></li><li><label class=''ee-shut''>geometry: Point (0.00,
-  0.00)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span class=''ee-k''>type:</span><span
-  class=''ee-v''>Point</span></li><li><label class=''ee-shut''>coordinates: [0, 0]<input
-  type=''checkbox'' class=''ee-toggle''></label><ul><li><span class=''ee-k''>0:</span><span
-  class=''ee-v''>0</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>0</span></li></ul></li></ul></li><li><label
-  class=''ee-shut''>properties: Object (1 property)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>foo:</span><span class=''ee-v''>bar</span></li></ul></li></ul></li></ul></li></ul></li>'
+  class=''ee-v''>0</span></li><li><label>geometry: Point (0.00, 0.00)<input type=''checkbox''></label><ul><li><span
+  class=''ee-k''>type:</span><span class=''ee-v''>Point</span></li><li><label>coordinates:
+  [0, 0]<input type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span
+  class=''ee-v''>0</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>0</span></li></ul></li></ul></li><li><label>properties:
+  Object (1 property)<input type=''checkbox''></label><ul><li><span class=''ee-k''>foo:</span><span
+  class=''ee-v''>bar</span></li></ul></li></ul></li></ul></li></ul></li>'

--- a/tests/data/test_regression_objects_filter_.yml
+++ b/tests/data/test_regression_objects_filter_.yml
@@ -1,4 +1,4 @@
-<li><label class='ee-shut'>Filter.eq<input type='checkbox' class='ee-toggle'></label><ul><li><span
-  class='ee-k'>type:</span><span class='ee-v'>Filter.eq</span></li><li><span class='ee-k'>leftField:</span><span
+<li><label>Filter.eq<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span
+  class='ee-v'>Filter.eq</span></li><li><span class='ee-k'>leftField:</span><span
   class='ee-v'>foo</span></li><li><span class='ee-k'>rightValue:</span><span class='ee-v'>bar</span></li></ul></li>
 ...

--- a/tests/data/test_regression_objects_image_collection_.yml
+++ b/tests/data/test_regression_objects_image_collection_.yml
@@ -1,40 +1,36 @@
-'<li><label class=''ee-shut''>ImageCollection (2 elements)<input type=''checkbox''
-  class=''ee-toggle''></label><ul><li><span class=''ee-k''>type:</span><span class=''ee-v''>ImageCollection</span></li><li><label
-  class=''ee-shut''>bands: []<input type=''checkbox'' class=''ee-toggle''></label><ul></ul></li><li><label
-  class=''ee-shut''>properties: Object (1 property)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>test_prop:</span><span class=''ee-v''>42</span></li></ul></li><li><label
-  class=''ee-shut''>features: List (2 elements)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><label
-  class=''ee-shut''>0: Image (1 band)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>type:</span><span class=''ee-v''>Image</span></li><li><label class=''ee-shut''>bands:
-  List (1 element)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><label
-  class=''ee-shut''>0: "constant", int ∈ [0, 0], EPSG:4326<input type=''checkbox''
-  class=''ee-toggle''></label><ul><li><span class=''ee-k''>id:</span><span class=''ee-v''>constant</span></li><li><span
-  class=''ee-k''>crs:</span><span class=''ee-v''>EPSG:4326</span></li><li><label class=''ee-shut''>crs_transform:
-  [1, 0, 0, 0, 1, 0]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>0:</span><span class=''ee-v''>1</span></li><li><span class=''ee-k''>1:</span><span
-  class=''ee-v''>0</span></li><li><span class=''ee-k''>2:</span><span class=''ee-v''>0</span></li><li><span
-  class=''ee-k''>3:</span><span class=''ee-v''>0</span></li><li><span class=''ee-k''>4:</span><span
-  class=''ee-v''>1</span></li><li><span class=''ee-k''>5:</span><span class=''ee-v''>0</span></li></ul></li><li><label
-  class=''ee-shut''>data_type: int ∈ [0, 0]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>type:</span><span class=''ee-v''>PixelType</span></li><li><span class=''ee-k''>max:</span><span
-  class=''ee-v''>0</span></li><li><span class=''ee-k''>min:</span><span class=''ee-v''>0</span></li><li><span
-  class=''ee-k''>precision:</span><span class=''ee-v''>int</span></li></ul></li></ul></li></ul></li><li><label
-  class=''ee-shut''>properties: Object (1 property)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>system:index:</span><span class=''ee-v''>0</span></li></ul></li></ul></li><li><label
-  class=''ee-shut''>1: Image (1 band)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>type:</span><span class=''ee-v''>Image</span></li><li><label class=''ee-shut''>bands:
-  List (1 element)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><label
-  class=''ee-shut''>0: "constant", int ∈ [1, 1], EPSG:4326<input type=''checkbox''
-  class=''ee-toggle''></label><ul><li><span class=''ee-k''>id:</span><span class=''ee-v''>constant</span></li><li><span
-  class=''ee-k''>crs:</span><span class=''ee-v''>EPSG:4326</span></li><li><label class=''ee-shut''>crs_transform:
-  [1, 0, 0, 0, 1, 0]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>0:</span><span class=''ee-v''>1</span></li><li><span class=''ee-k''>1:</span><span
-  class=''ee-v''>0</span></li><li><span class=''ee-k''>2:</span><span class=''ee-v''>0</span></li><li><span
-  class=''ee-k''>3:</span><span class=''ee-v''>0</span></li><li><span class=''ee-k''>4:</span><span
-  class=''ee-v''>1</span></li><li><span class=''ee-k''>5:</span><span class=''ee-v''>0</span></li></ul></li><li><label
-  class=''ee-shut''>data_type: int ∈ [1, 1]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>type:</span><span class=''ee-v''>PixelType</span></li><li><span class=''ee-k''>max:</span><span
-  class=''ee-v''>1</span></li><li><span class=''ee-k''>min:</span><span class=''ee-v''>1</span></li><li><span
-  class=''ee-k''>precision:</span><span class=''ee-v''>int</span></li></ul></li></ul></li></ul></li><li><label
-  class=''ee-shut''>properties: Object (1 property)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>system:index:</span><span class=''ee-v''>1</span></li></ul></li></ul></li></ul></li></ul></li>'
+'<li><label>ImageCollection (2 elements)<input type=''checkbox''></label><ul><li><span
+  class=''ee-k''>type:</span><span class=''ee-v''>ImageCollection</span></li><li><label>bands:
+  []<input type=''checkbox''></label><ul></ul></li><li><label>properties: Object (1
+  property)<input type=''checkbox''></label><ul><li><span class=''ee-k''>test_prop:</span><span
+  class=''ee-v''>42</span></li></ul></li><li><label>features: List (2 elements)<input
+  type=''checkbox''></label><ul><li><label>0: Image (1 band)<input type=''checkbox''></label><ul><li><span
+  class=''ee-k''>type:</span><span class=''ee-v''>Image</span></li><li><label>bands:
+  List (1 element)<input type=''checkbox''></label><ul><li><label>0: "constant", int
+  ∈ [0, 0], EPSG:4326<input type=''checkbox''></label><ul><li><span class=''ee-k''>id:</span><span
+  class=''ee-v''>constant</span></li><li><span class=''ee-k''>crs:</span><span class=''ee-v''>EPSG:4326</span></li><li><label>crs_transform:
+  [1, 0, 0, 0, 1, 0]<input type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span
+  class=''ee-v''>1</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>0</span></li><li><span
+  class=''ee-k''>2:</span><span class=''ee-v''>0</span></li><li><span class=''ee-k''>3:</span><span
+  class=''ee-v''>0</span></li><li><span class=''ee-k''>4:</span><span class=''ee-v''>1</span></li><li><span
+  class=''ee-k''>5:</span><span class=''ee-v''>0</span></li></ul></li><li><label>data_type:
+  int ∈ [0, 0]<input type=''checkbox''></label><ul><li><span class=''ee-k''>type:</span><span
+  class=''ee-v''>PixelType</span></li><li><span class=''ee-k''>max:</span><span class=''ee-v''>0</span></li><li><span
+  class=''ee-k''>min:</span><span class=''ee-v''>0</span></li><li><span class=''ee-k''>precision:</span><span
+  class=''ee-v''>int</span></li></ul></li></ul></li></ul></li><li><label>properties:
+  Object (1 property)<input type=''checkbox''></label><ul><li><span class=''ee-k''>system:index:</span><span
+  class=''ee-v''>0</span></li></ul></li></ul></li><li><label>1: Image (1 band)<input
+  type=''checkbox''></label><ul><li><span class=''ee-k''>type:</span><span class=''ee-v''>Image</span></li><li><label>bands:
+  List (1 element)<input type=''checkbox''></label><ul><li><label>0: "constant", int
+  ∈ [1, 1], EPSG:4326<input type=''checkbox''></label><ul><li><span class=''ee-k''>id:</span><span
+  class=''ee-v''>constant</span></li><li><span class=''ee-k''>crs:</span><span class=''ee-v''>EPSG:4326</span></li><li><label>crs_transform:
+  [1, 0, 0, 0, 1, 0]<input type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span
+  class=''ee-v''>1</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>0</span></li><li><span
+  class=''ee-k''>2:</span><span class=''ee-v''>0</span></li><li><span class=''ee-k''>3:</span><span
+  class=''ee-v''>0</span></li><li><span class=''ee-k''>4:</span><span class=''ee-v''>1</span></li><li><span
+  class=''ee-k''>5:</span><span class=''ee-v''>0</span></li></ul></li><li><label>data_type:
+  int ∈ [1, 1]<input type=''checkbox''></label><ul><li><span class=''ee-k''>type:</span><span
+  class=''ee-v''>PixelType</span></li><li><span class=''ee-k''>max:</span><span class=''ee-v''>1</span></li><li><span
+  class=''ee-k''>min:</span><span class=''ee-v''>1</span></li><li><span class=''ee-k''>precision:</span><span
+  class=''ee-v''>int</span></li></ul></li></ul></li></ul></li><li><label>properties:
+  Object (1 property)<input type=''checkbox''></label><ul><li><span class=''ee-k''>system:index:</span><span
+  class=''ee-v''>1</span></li></ul></li></ul></li></ul></li></ul></li>'

--- a/tests/data/test_regression_objects_kernel_.yml
+++ b/tests/data/test_regression_objects_kernel_.yml
@@ -1,6 +1,5 @@
-"<li><label class='ee-shut'>Kernel.gaussian<input type='checkbox' class='ee-toggle'></label><ul><li><span\
-  \ class='ee-k'>type:</span><span class='ee-v'>Kernel.gaussian</span></li><li><label\
-  \ class='ee-shut'>center: [3, 3]<input type='checkbox' class='ee-toggle'></label><ul><li><span\
+"<li><label>Kernel.gaussian<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span\
+  \ class='ee-v'>Kernel.gaussian</span></li><li><label>center: [3, 3]<input type='checkbox'></label><ul><li><span\
   \ class='ee-k'>0:</span><span class='ee-v'>3</span></li><li><span class='ee-k'>1:</span><span\
   \ class='ee-v'>3</span></li></ul></li><li><span class='ee-k'>radius:</span><span\
   \ class='ee-v'>3</span></li><li><span class='ee-k'>weights:</span><span class='ee-v'>\n\

--- a/tests/data/test_regression_objects_linearring_.yml
+++ b/tests/data/test_regression_objects_linearring_.yml
@@ -1,13 +1,11 @@
-'<li><label class=''ee-shut''>LinearRing (4 vertices)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>type:</span><span class=''ee-v''>LinearRing</span></li><li><label
-  class=''ee-shut''>coordinates: [[0, 0], [1, 1], [2, 2], [0, 0]]<input type=''checkbox''
-  class=''ee-toggle''></label><ul><li><label class=''ee-shut''>0: [0, 0]<input type=''checkbox''
-  class=''ee-toggle''></label><ul><li><span class=''ee-k''>0:</span><span class=''ee-v''>0</span></li><li><span
-  class=''ee-k''>1:</span><span class=''ee-v''>0</span></li></ul></li><li><label class=''ee-shut''>1:
-  [1, 1]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span class=''ee-k''>0:</span><span
-  class=''ee-v''>1</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>1</span></li></ul></li><li><label
-  class=''ee-shut''>2: [2, 2]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>0:</span><span class=''ee-v''>2</span></li><li><span class=''ee-k''>1:</span><span
-  class=''ee-v''>2</span></li></ul></li><li><label class=''ee-shut''>3: [0, 0]<input
-  type=''checkbox'' class=''ee-toggle''></label><ul><li><span class=''ee-k''>0:</span><span
+'<li><label>LinearRing (4 vertices)<input type=''checkbox''></label><ul><li><span
+  class=''ee-k''>type:</span><span class=''ee-v''>LinearRing</span></li><li><label>coordinates:
+  [[0, 0], [1, 1], [2, 2], [0, 0]]<input type=''checkbox''></label><ul><li><label>0:
+  [0, 0]<input type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span
+  class=''ee-v''>0</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>0</span></li></ul></li><li><label>1:
+  [1, 1]<input type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span
+  class=''ee-v''>1</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>1</span></li></ul></li><li><label>2:
+  [2, 2]<input type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span
+  class=''ee-v''>2</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>2</span></li></ul></li><li><label>3:
+  [0, 0]<input type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span
   class=''ee-v''>0</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>0</span></li></ul></li></ul></li></ul></li>'

--- a/tests/data/test_regression_objects_linestring_.yml
+++ b/tests/data/test_regression_objects_linestring_.yml
@@ -1,11 +1,9 @@
-'<li><label class=''ee-shut''>LineString (3 vertices)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>type:</span><span class=''ee-v''>LineString</span></li><li><label
-  class=''ee-shut''>coordinates: [[1, 1], [2, 2], [3, 3]]<input type=''checkbox''
-  class=''ee-toggle''></label><ul><li><label class=''ee-shut''>0: [1, 1]<input type=''checkbox''
-  class=''ee-toggle''></label><ul><li><span class=''ee-k''>0:</span><span class=''ee-v''>1</span></li><li><span
-  class=''ee-k''>1:</span><span class=''ee-v''>1</span></li></ul></li><li><label class=''ee-shut''>1:
-  [2, 2]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span class=''ee-k''>0:</span><span
-  class=''ee-v''>2</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>2</span></li></ul></li><li><label
-  class=''ee-shut''>2: [3, 3]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>0:</span><span class=''ee-v''>3</span></li><li><span class=''ee-k''>1:</span><span
-  class=''ee-v''>3</span></li></ul></li></ul></li></ul></li>'
+'<li><label>LineString (3 vertices)<input type=''checkbox''></label><ul><li><span
+  class=''ee-k''>type:</span><span class=''ee-v''>LineString</span></li><li><label>coordinates:
+  [[1, 1], [2, 2], [3, 3]]<input type=''checkbox''></label><ul><li><label>0: [1, 1]<input
+  type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span class=''ee-v''>1</span></li><li><span
+  class=''ee-k''>1:</span><span class=''ee-v''>1</span></li></ul></li><li><label>1:
+  [2, 2]<input type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span
+  class=''ee-v''>2</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>2</span></li></ul></li><li><label>2:
+  [3, 3]<input type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span
+  class=''ee-v''>3</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>3</span></li></ul></li></ul></li></ul></li>'

--- a/tests/data/test_regression_objects_long_list_.yml
+++ b/tests/data/test_regression_objects_long_list_.yml
@@ -1,16 +1,16 @@
-<li><label class='ee-shut'>List (21 elements)<input type='checkbox' class='ee-toggle'></label><ul><li><span
-  class='ee-k'>0:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>1:</span><span
-  class='ee-v'>1</span></li><li><span class='ee-k'>2:</span><span class='ee-v'>2</span></li><li><span
-  class='ee-k'>3:</span><span class='ee-v'>3</span></li><li><span class='ee-k'>4:</span><span
-  class='ee-v'>4</span></li><li><span class='ee-k'>5:</span><span class='ee-v'>5</span></li><li><span
-  class='ee-k'>6:</span><span class='ee-v'>6</span></li><li><span class='ee-k'>7:</span><span
-  class='ee-v'>7</span></li><li><span class='ee-k'>8:</span><span class='ee-v'>8</span></li><li><span
-  class='ee-k'>9:</span><span class='ee-v'>9</span></li><li><span class='ee-k'>10:</span><span
-  class='ee-v'>10</span></li><li><span class='ee-k'>11:</span><span class='ee-v'>11</span></li><li><span
-  class='ee-k'>12:</span><span class='ee-v'>12</span></li><li><span class='ee-k'>13:</span><span
-  class='ee-v'>13</span></li><li><span class='ee-k'>14:</span><span class='ee-v'>14</span></li><li><span
-  class='ee-k'>15:</span><span class='ee-v'>15</span></li><li><span class='ee-k'>16:</span><span
-  class='ee-v'>16</span></li><li><span class='ee-k'>17:</span><span class='ee-v'>17</span></li><li><span
-  class='ee-k'>18:</span><span class='ee-v'>18</span></li><li><span class='ee-k'>19:</span><span
-  class='ee-v'>19</span></li><li><span class='ee-k'>20:</span><span class='ee-v'>20</span></li></ul></li>
+<li><label>List (21 elements)<input type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span
+  class='ee-v'>0</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>1</span></li><li><span
+  class='ee-k'>2:</span><span class='ee-v'>2</span></li><li><span class='ee-k'>3:</span><span
+  class='ee-v'>3</span></li><li><span class='ee-k'>4:</span><span class='ee-v'>4</span></li><li><span
+  class='ee-k'>5:</span><span class='ee-v'>5</span></li><li><span class='ee-k'>6:</span><span
+  class='ee-v'>6</span></li><li><span class='ee-k'>7:</span><span class='ee-v'>7</span></li><li><span
+  class='ee-k'>8:</span><span class='ee-v'>8</span></li><li><span class='ee-k'>9:</span><span
+  class='ee-v'>9</span></li><li><span class='ee-k'>10:</span><span class='ee-v'>10</span></li><li><span
+  class='ee-k'>11:</span><span class='ee-v'>11</span></li><li><span class='ee-k'>12:</span><span
+  class='ee-v'>12</span></li><li><span class='ee-k'>13:</span><span class='ee-v'>13</span></li><li><span
+  class='ee-k'>14:</span><span class='ee-v'>14</span></li><li><span class='ee-k'>15:</span><span
+  class='ee-v'>15</span></li><li><span class='ee-k'>16:</span><span class='ee-v'>16</span></li><li><span
+  class='ee-k'>17:</span><span class='ee-v'>17</span></li><li><span class='ee-k'>18:</span><span
+  class='ee-v'>18</span></li><li><span class='ee-k'>19:</span><span class='ee-v'>19</span></li><li><span
+  class='ee-k'>20:</span><span class='ee-v'>20</span></li></ul></li>
 ...

--- a/tests/data/test_regression_objects_multilinestring_.yml
+++ b/tests/data/test_regression_objects_multilinestring_.yml
@@ -1,9 +1,7 @@
-'<li><label class=''ee-shut''>MultiLineString<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>type:</span><span class=''ee-v''>MultiLineString</span></li><li><label
-  class=''ee-shut''>coordinates: [[[0, 0], [1, 1]]]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><label
-  class=''ee-shut''>0: [[0, 0], [1, 1]]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><label
-  class=''ee-shut''>0: [0, 0]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>0:</span><span class=''ee-v''>0</span></li><li><span class=''ee-k''>1:</span><span
-  class=''ee-v''>0</span></li></ul></li><li><label class=''ee-shut''>1: [1, 1]<input
-  type=''checkbox'' class=''ee-toggle''></label><ul><li><span class=''ee-k''>0:</span><span
+'<li><label>MultiLineString<input type=''checkbox''></label><ul><li><span class=''ee-k''>type:</span><span
+  class=''ee-v''>MultiLineString</span></li><li><label>coordinates: [[[0, 0], [1,
+  1]]]<input type=''checkbox''></label><ul><li><label>0: [[0, 0], [1, 1]]<input type=''checkbox''></label><ul><li><label>0:
+  [0, 0]<input type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span
+  class=''ee-v''>0</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>0</span></li></ul></li><li><label>1:
+  [1, 1]<input type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span
   class=''ee-v''>1</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>1</span></li></ul></li></ul></li></ul></li></ul></li>'

--- a/tests/data/test_regression_objects_multipoint_.yml
+++ b/tests/data/test_regression_objects_multipoint_.yml
@@ -1,8 +1,7 @@
-'<li><label class=''ee-shut''>MultiPoint (2 vertices)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>type:</span><span class=''ee-v''>MultiPoint</span></li><li><label
-  class=''ee-shut''>coordinates: [[1, 1], [2, 2]]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><label
-  class=''ee-shut''>0: [1, 1]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>0:</span><span class=''ee-v''>1</span></li><li><span class=''ee-k''>1:</span><span
-  class=''ee-v''>1</span></li></ul></li><li><label class=''ee-shut''>1: [2, 2]<input
-  type=''checkbox'' class=''ee-toggle''></label><ul><li><span class=''ee-k''>0:</span><span
+'<li><label>MultiPoint (2 vertices)<input type=''checkbox''></label><ul><li><span
+  class=''ee-k''>type:</span><span class=''ee-v''>MultiPoint</span></li><li><label>coordinates:
+  [[1, 1], [2, 2]]<input type=''checkbox''></label><ul><li><label>0: [1, 1]<input
+  type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span class=''ee-v''>1</span></li><li><span
+  class=''ee-k''>1:</span><span class=''ee-v''>1</span></li></ul></li><li><label>1:
+  [2, 2]<input type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span
   class=''ee-v''>2</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>2</span></li></ul></li></ul></li></ul></li>'

--- a/tests/data/test_regression_objects_multipolygon_.yml
+++ b/tests/data/test_regression_objects_multipolygon_.yml
@@ -1,26 +1,22 @@
-'<li><label class=''ee-shut''>MultiPolygon (8 vertices)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>type:</span><span class=''ee-v''>MultiPolygon</span></li><li><label
-  class=''ee-shut''>coordinates: List (1 element)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><label
-  class=''ee-shut''>0: List (2 elements)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><label
-  class=''ee-shut''>0: [[0, 0], [1, 1], [2, 2], [0, 0]]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><label
-  class=''ee-shut''>0: [0, 0]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
+'<li><label>MultiPolygon (8 vertices)<input type=''checkbox''></label><ul><li><span
+  class=''ee-k''>type:</span><span class=''ee-v''>MultiPolygon</span></li><li><label>coordinates:
+  List (1 element)<input type=''checkbox''></label><ul><li><label>0: List (2 elements)<input
+  type=''checkbox''></label><ul><li><label>0: [[0, 0], [1, 1], [2, 2], [0, 0]]<input
+  type=''checkbox''></label><ul><li><label>0: [0, 0]<input type=''checkbox''></label><ul><li><span
   class=''ee-k''>0:</span><span class=''ee-v''>0</span></li><li><span class=''ee-k''>1:</span><span
-  class=''ee-v''>0</span></li></ul></li><li><label class=''ee-shut''>1: [1, 1]<input
-  type=''checkbox'' class=''ee-toggle''></label><ul><li><span class=''ee-k''>0:</span><span
-  class=''ee-v''>1</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>1</span></li></ul></li><li><label
-  class=''ee-shut''>2: [2, 2]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>0:</span><span class=''ee-v''>2</span></li><li><span class=''ee-k''>1:</span><span
-  class=''ee-v''>2</span></li></ul></li><li><label class=''ee-shut''>3: [0, 0]<input
-  type=''checkbox'' class=''ee-toggle''></label><ul><li><span class=''ee-k''>0:</span><span
-  class=''ee-v''>0</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>0</span></li></ul></li></ul></li><li><label
-  class=''ee-shut''>1: [[4, 6], [3, 2], [1, 2], [4, 6]]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><label
-  class=''ee-shut''>0: [4, 6]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>0:</span><span class=''ee-v''>4</span></li><li><span class=''ee-k''>1:</span><span
-  class=''ee-v''>6</span></li></ul></li><li><label class=''ee-shut''>1: [3, 2]<input
-  type=''checkbox'' class=''ee-toggle''></label><ul><li><span class=''ee-k''>0:</span><span
-  class=''ee-v''>3</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>2</span></li></ul></li><li><label
-  class=''ee-shut''>2: [1, 2]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
+  class=''ee-v''>0</span></li></ul></li><li><label>1: [1, 1]<input type=''checkbox''></label><ul><li><span
   class=''ee-k''>0:</span><span class=''ee-v''>1</span></li><li><span class=''ee-k''>1:</span><span
-  class=''ee-v''>2</span></li></ul></li><li><label class=''ee-shut''>3: [4, 6]<input
-  type=''checkbox'' class=''ee-toggle''></label><ul><li><span class=''ee-k''>0:</span><span
-  class=''ee-v''>4</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>6</span></li></ul></li></ul></li></ul></li></ul></li></ul></li>'
+  class=''ee-v''>1</span></li></ul></li><li><label>2: [2, 2]<input type=''checkbox''></label><ul><li><span
+  class=''ee-k''>0:</span><span class=''ee-v''>2</span></li><li><span class=''ee-k''>1:</span><span
+  class=''ee-v''>2</span></li></ul></li><li><label>3: [0, 0]<input type=''checkbox''></label><ul><li><span
+  class=''ee-k''>0:</span><span class=''ee-v''>0</span></li><li><span class=''ee-k''>1:</span><span
+  class=''ee-v''>0</span></li></ul></li></ul></li><li><label>1: [[4, 6], [3, 2], [1,
+  2], [4, 6]]<input type=''checkbox''></label><ul><li><label>0: [4, 6]<input type=''checkbox''></label><ul><li><span
+  class=''ee-k''>0:</span><span class=''ee-v''>4</span></li><li><span class=''ee-k''>1:</span><span
+  class=''ee-v''>6</span></li></ul></li><li><label>1: [3, 2]<input type=''checkbox''></label><ul><li><span
+  class=''ee-k''>0:</span><span class=''ee-v''>3</span></li><li><span class=''ee-k''>1:</span><span
+  class=''ee-v''>2</span></li></ul></li><li><label>2: [1, 2]<input type=''checkbox''></label><ul><li><span
+  class=''ee-k''>0:</span><span class=''ee-v''>1</span></li><li><span class=''ee-k''>1:</span><span
+  class=''ee-v''>2</span></li></ul></li><li><label>3: [4, 6]<input type=''checkbox''></label><ul><li><span
+  class=''ee-k''>0:</span><span class=''ee-v''>4</span></li><li><span class=''ee-k''>1:</span><span
+  class=''ee-v''>6</span></li></ul></li></ul></li></ul></li></ul></li></ul></li>'

--- a/tests/data/test_regression_objects_null_feature_.yml
+++ b/tests/data/test_regression_objects_null_feature_.yml
@@ -1,4 +1,4 @@
-'<li><label class=''ee-shut''>Feature (0 properties)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>type:</span><span class=''ee-v''>Feature</span></li><li><span class=''ee-k''>geometry:</span><span
-  class=''ee-v''>None</span></li><li><label class=''ee-shut''>properties: Object (0
-  properties)<input type=''checkbox'' class=''ee-toggle''></label><ul></ul></li></ul></li>'
+'<li><label>Feature (0 properties)<input type=''checkbox''></label><ul><li><span class=''ee-k''>type:</span><span
+  class=''ee-v''>Feature</span></li><li><span class=''ee-k''>geometry:</span><span
+  class=''ee-v''>None</span></li><li><label>properties: Object (0 properties)<input
+  type=''checkbox''></label><ul></ul></li></ul></li>'

--- a/tests/data/test_regression_objects_pixel_custom_.yml
+++ b/tests/data/test_regression_objects_pixel_custom_.yml
@@ -1,5 +1,5 @@
-<li><label class='ee-shut'>int ∈ [10, 255]<input type='checkbox' class='ee-toggle'></label><ul><li><span
-  class='ee-k'>type:</span><span class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span
-  class='ee-v'>255</span></li><li><span class='ee-k'>min:</span><span class='ee-v'>10</span></li><li><span
-  class='ee-k'>precision:</span><span class='ee-v'>int</span></li></ul></li>
+<li><label>int ∈ [10, 255]<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span
+  class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span class='ee-v'>255</span></li><li><span
+  class='ee-k'>min:</span><span class='ee-v'>10</span></li><li><span class='ee-k'>precision:</span><span
+  class='ee-v'>int</span></li></ul></li>
 ...

--- a/tests/data/test_regression_objects_pixel_double_.yml
+++ b/tests/data/test_regression_objects_pixel_double_.yml
@@ -1,4 +1,4 @@
-<li><label class='ee-shut'>double<input type='checkbox' class='ee-toggle'></label><ul><li><span
-  class='ee-k'>type:</span><span class='ee-v'>PixelType</span></li><li><span class='ee-k'>precision:</span><span
+<li><label>double<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span
+  class='ee-v'>PixelType</span></li><li><span class='ee-k'>precision:</span><span
   class='ee-v'>double</span></li></ul></li>
 ...

--- a/tests/data/test_regression_objects_pixel_float_.yml
+++ b/tests/data/test_regression_objects_pixel_float_.yml
@@ -1,4 +1,4 @@
-<li><label class='ee-shut'>float<input type='checkbox' class='ee-toggle'></label><ul><li><span
-  class='ee-k'>type:</span><span class='ee-v'>PixelType</span></li><li><span class='ee-k'>precision:</span><span
+<li><label>float<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span
+  class='ee-v'>PixelType</span></li><li><span class='ee-k'>precision:</span><span
   class='ee-v'>float</span></li></ul></li>
 ...

--- a/tests/data/test_regression_objects_pixel_int16_.yml
+++ b/tests/data/test_regression_objects_pixel_int16_.yml
@@ -1,5 +1,5 @@
-<li><label class='ee-shut'>signed int16<input type='checkbox' class='ee-toggle'></label><ul><li><span
-  class='ee-k'>type:</span><span class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span
-  class='ee-v'>32767</span></li><li><span class='ee-k'>min:</span><span class='ee-v'>-32768</span></li><li><span
-  class='ee-k'>precision:</span><span class='ee-v'>int</span></li></ul></li>
+<li><label>signed int16<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span
+  class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span class='ee-v'>32767</span></li><li><span
+  class='ee-k'>min:</span><span class='ee-v'>-32768</span></li><li><span class='ee-k'>precision:</span><span
+  class='ee-v'>int</span></li></ul></li>
 ...

--- a/tests/data/test_regression_objects_pixel_int32_.yml
+++ b/tests/data/test_regression_objects_pixel_int32_.yml
@@ -1,5 +1,5 @@
-<li><label class='ee-shut'>signed int32<input type='checkbox' class='ee-toggle'></label><ul><li><span
-  class='ee-k'>type:</span><span class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span
-  class='ee-v'>2147483647</span></li><li><span class='ee-k'>min:</span><span class='ee-v'>-2147483648</span></li><li><span
-  class='ee-k'>precision:</span><span class='ee-v'>int</span></li></ul></li>
+<li><label>signed int32<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span
+  class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span class='ee-v'>2147483647</span></li><li><span
+  class='ee-k'>min:</span><span class='ee-v'>-2147483648</span></li><li><span class='ee-k'>precision:</span><span
+  class='ee-v'>int</span></li></ul></li>
 ...

--- a/tests/data/test_regression_objects_pixel_int64_.yml
+++ b/tests/data/test_regression_objects_pixel_int64_.yml
@@ -1,6 +1,5 @@
-<li><label class='ee-shut'>signed int64<input type='checkbox' class='ee-toggle'></label><ul><li><span
-  class='ee-k'>type:</span><span class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span
-  class='ee-v'>9.223372036854776e+18</span></li><li><span class='ee-k'>min:</span><span
-  class='ee-v'>-9.223372036854776e+18</span></li><li><span class='ee-k'>precision:</span><span
-  class='ee-v'>int</span></li></ul></li>
+<li><label>signed int64<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span
+  class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span class='ee-v'>9.223372036854776e+18</span></li><li><span
+  class='ee-k'>min:</span><span class='ee-v'>-9.223372036854776e+18</span></li><li><span
+  class='ee-k'>precision:</span><span class='ee-v'>int</span></li></ul></li>
 ...

--- a/tests/data/test_regression_objects_pixel_int8_.yml
+++ b/tests/data/test_regression_objects_pixel_int8_.yml
@@ -1,5 +1,5 @@
-<li><label class='ee-shut'>signed int8<input type='checkbox' class='ee-toggle'></label><ul><li><span
-  class='ee-k'>type:</span><span class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span
-  class='ee-v'>127</span></li><li><span class='ee-k'>min:</span><span class='ee-v'>-128</span></li><li><span
-  class='ee-k'>precision:</span><span class='ee-v'>int</span></li></ul></li>
+<li><label>signed int8<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span
+  class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span class='ee-v'>127</span></li><li><span
+  class='ee-k'>min:</span><span class='ee-v'>-128</span></li><li><span class='ee-k'>precision:</span><span
+  class='ee-v'>int</span></li></ul></li>
 ...

--- a/tests/data/test_regression_objects_pixel_uint16_.yml
+++ b/tests/data/test_regression_objects_pixel_uint16_.yml
@@ -1,5 +1,5 @@
-<li><label class='ee-shut'>unsigned int16<input type='checkbox' class='ee-toggle'></label><ul><li><span
-  class='ee-k'>type:</span><span class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span
-  class='ee-v'>65535</span></li><li><span class='ee-k'>min:</span><span class='ee-v'>0</span></li><li><span
-  class='ee-k'>precision:</span><span class='ee-v'>int</span></li></ul></li>
+<li><label>unsigned int16<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span
+  class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span class='ee-v'>65535</span></li><li><span
+  class='ee-k'>min:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>precision:</span><span
+  class='ee-v'>int</span></li></ul></li>
 ...

--- a/tests/data/test_regression_objects_pixel_uint32_.yml
+++ b/tests/data/test_regression_objects_pixel_uint32_.yml
@@ -1,5 +1,5 @@
-<li><label class='ee-shut'>unsigned int32<input type='checkbox' class='ee-toggle'></label><ul><li><span
-  class='ee-k'>type:</span><span class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span
-  class='ee-v'>4294967295</span></li><li><span class='ee-k'>min:</span><span class='ee-v'>0</span></li><li><span
-  class='ee-k'>precision:</span><span class='ee-v'>int</span></li></ul></li>
+<li><label>unsigned int32<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span
+  class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span class='ee-v'>4294967295</span></li><li><span
+  class='ee-k'>min:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>precision:</span><span
+  class='ee-v'>int</span></li></ul></li>
 ...

--- a/tests/data/test_regression_objects_pixel_uint8_.yml
+++ b/tests/data/test_regression_objects_pixel_uint8_.yml
@@ -1,5 +1,5 @@
-<li><label class='ee-shut'>unsigned int8<input type='checkbox' class='ee-toggle'></label><ul><li><span
-  class='ee-k'>type:</span><span class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span
-  class='ee-v'>255</span></li><li><span class='ee-k'>min:</span><span class='ee-v'>0</span></li><li><span
-  class='ee-k'>precision:</span><span class='ee-v'>int</span></li></ul></li>
+<li><label>unsigned int8<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span
+  class='ee-v'>PixelType</span></li><li><span class='ee-k'>max:</span><span class='ee-v'>255</span></li><li><span
+  class='ee-k'>min:</span><span class='ee-v'>0</span></li><li><span class='ee-k'>precision:</span><span
+  class='ee-v'>int</span></li></ul></li>
 ...

--- a/tests/data/test_regression_objects_point_.yml
+++ b/tests/data/test_regression_objects_point_.yml
@@ -1,5 +1,4 @@
-'<li><label class=''ee-shut''>Point (1.11, 2.00)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>type:</span><span class=''ee-v''>Point</span></li><li><label class=''ee-shut''>coordinates:
-  [1.112312, 2]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
+'<li><label>Point (1.11, 2.00)<input type=''checkbox''></label><ul><li><span class=''ee-k''>type:</span><span
+  class=''ee-v''>Point</span></li><li><label>coordinates: [1.112312, 2]<input type=''checkbox''></label><ul><li><span
   class=''ee-k''>0:</span><span class=''ee-v''>1.112312</span></li><li><span class=''ee-k''>1:</span><span
   class=''ee-v''>2</span></li></ul></li></ul></li>'

--- a/tests/data/test_regression_objects_polygon_.yml
+++ b/tests/data/test_regression_objects_polygon_.yml
@@ -1,14 +1,12 @@
-'<li><label class=''ee-shut''>Polygon (4 vertices)<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>type:</span><span class=''ee-v''>Polygon</span></li><li><label class=''ee-shut''>coordinates:
-  [[[0, 0], [1, 1], [2, 2], [0, 0]]]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><label
-  class=''ee-shut''>0: [[0, 0], [1, 1], [2, 2], [0, 0]]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><label
-  class=''ee-shut''>0: [0, 0]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
+'<li><label>Polygon (4 vertices)<input type=''checkbox''></label><ul><li><span class=''ee-k''>type:</span><span
+  class=''ee-v''>Polygon</span></li><li><label>coordinates: [[[0, 0], [1, 1], [2,
+  2], [0, 0]]]<input type=''checkbox''></label><ul><li><label>0: [[0, 0], [1, 1],
+  [2, 2], [0, 0]]<input type=''checkbox''></label><ul><li><label>0: [0, 0]<input type=''checkbox''></label><ul><li><span
   class=''ee-k''>0:</span><span class=''ee-v''>0</span></li><li><span class=''ee-k''>1:</span><span
-  class=''ee-v''>0</span></li></ul></li><li><label class=''ee-shut''>1: [1, 1]<input
-  type=''checkbox'' class=''ee-toggle''></label><ul><li><span class=''ee-k''>0:</span><span
-  class=''ee-v''>1</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>1</span></li></ul></li><li><label
-  class=''ee-shut''>2: [2, 2]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
+  class=''ee-v''>0</span></li></ul></li><li><label>1: [1, 1]<input type=''checkbox''></label><ul><li><span
+  class=''ee-k''>0:</span><span class=''ee-v''>1</span></li><li><span class=''ee-k''>1:</span><span
+  class=''ee-v''>1</span></li></ul></li><li><label>2: [2, 2]<input type=''checkbox''></label><ul><li><span
   class=''ee-k''>0:</span><span class=''ee-v''>2</span></li><li><span class=''ee-k''>1:</span><span
-  class=''ee-v''>2</span></li></ul></li><li><label class=''ee-shut''>3: [0, 0]<input
-  type=''checkbox'' class=''ee-toggle''></label><ul><li><span class=''ee-k''>0:</span><span
-  class=''ee-v''>0</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>0</span></li></ul></li></ul></li></ul></li></ul></li>'
+  class=''ee-v''>2</span></li></ul></li><li><label>3: [0, 0]<input type=''checkbox''></label><ul><li><span
+  class=''ee-k''>0:</span><span class=''ee-v''>0</span></li><li><span class=''ee-k''>1:</span><span
+  class=''ee-v''>0</span></li></ul></li></ul></li></ul></li></ul></li>'

--- a/tests/data/test_regression_objects_projection_.yml
+++ b/tests/data/test_regression_objects_projection_.yml
@@ -1,8 +1,7 @@
-'<li><label class=''ee-shut''>Projection<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>type:</span><span class=''ee-v''>Projection</span></li><li><span
-  class=''ee-k''>crs:</span><span class=''ee-v''>EPSG:5070</span></li><li><label class=''ee-shut''>transform:
-  [100, 0, 0, 0, 100, 0]<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>0:</span><span class=''ee-v''>100</span></li><li><span class=''ee-k''>1:</span><span
-  class=''ee-v''>0</span></li><li><span class=''ee-k''>2:</span><span class=''ee-v''>0</span></li><li><span
-  class=''ee-k''>3:</span><span class=''ee-v''>0</span></li><li><span class=''ee-k''>4:</span><span
-  class=''ee-v''>100</span></li><li><span class=''ee-k''>5:</span><span class=''ee-v''>0</span></li></ul></li></ul></li>'
+'<li><label>Projection<input type=''checkbox''></label><ul><li><span class=''ee-k''>type:</span><span
+  class=''ee-v''>Projection</span></li><li><span class=''ee-k''>crs:</span><span class=''ee-v''>EPSG:5070</span></li><li><label>transform:
+  [100, 0, 0, 0, 100, 0]<input type=''checkbox''></label><ul><li><span class=''ee-k''>0:</span><span
+  class=''ee-v''>100</span></li><li><span class=''ee-k''>1:</span><span class=''ee-v''>0</span></li><li><span
+  class=''ee-k''>2:</span><span class=''ee-v''>0</span></li><li><span class=''ee-k''>3:</span><span
+  class=''ee-v''>0</span></li><li><span class=''ee-k''>4:</span><span class=''ee-v''>100</span></li><li><span
+  class=''ee-k''>5:</span><span class=''ee-v''>0</span></li></ul></li></ul></li>'

--- a/tests/data/test_regression_objects_reducer_.yml
+++ b/tests/data/test_regression_objects_reducer_.yml
@@ -1,4 +1,4 @@
-<li><label class='ee-shut'>Reducer.max<input type='checkbox' class='ee-toggle'></label><ul><li><span
-  class='ee-k'>type:</span><span class='ee-v'>Reducer.max</span></li><li><span class='ee-k'>numInputs:</span><span
+<li><label>Reducer.max<input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span
+  class='ee-v'>Reducer.max</span></li><li><span class='ee-k'>numInputs:</span><span
   class='ee-v'>5</span></li></ul></li>
 ...

--- a/tests/data/test_regression_objects_short_list_.yml
+++ b/tests/data/test_regression_objects_short_list_.yml
@@ -1,5 +1,5 @@
-<li><label class='ee-shut'>[1, 2, 3, 4]<input type='checkbox' class='ee-toggle'></label><ul><li><span
-  class='ee-k'>0:</span><span class='ee-v'>1</span></li><li><span class='ee-k'>1:</span><span
-  class='ee-v'>2</span></li><li><span class='ee-k'>2:</span><span class='ee-v'>3</span></li><li><span
-  class='ee-k'>3:</span><span class='ee-v'>4</span></li></ul></li>
+<li><label>[1, 2, 3, 4]<input type='checkbox'></label><ul><li><span class='ee-k'>0:</span><span
+  class='ee-v'>1</span></li><li><span class='ee-k'>1:</span><span class='ee-v'>2</span></li><li><span
+  class='ee-k'>2:</span><span class='ee-v'>3</span></li><li><span class='ee-k'>3:</span><span
+  class='ee-v'>4</span></li></ul></li>
 ...

--- a/tests/data/test_regression_objects_type_dict_.yml
+++ b/tests/data/test_regression_objects_type_dict_.yml
@@ -1,4 +1,3 @@
-<li><label class='ee-shut'>Foo bar <input type='checkbox' class='ee-toggle'></label><ul><li><span
-  class='ee-k'>type:</span><span class='ee-v'>Foo</span></li><li><span class='ee-k'>id:</span><span
-  class='ee-v'>bar</span></li></ul></li>
+<li><label>Foo bar <input type='checkbox'></label><ul><li><span class='ee-k'>type:</span><span
+  class='ee-v'>Foo</span></li><li><span class='ee-k'>id:</span><span class='ee-v'>bar</span></li></ul></li>
 ...

--- a/tests/data/test_regression_objects_unbounded_band_dict_.yml
+++ b/tests/data/test_regression_objects_unbounded_band_dict_.yml
@@ -1,6 +1,5 @@
-'<li><label class=''ee-shut''>"B1", unsigned int16<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
-  class=''ee-k''>id:</span><span class=''ee-v''>B1</span></li><li><label class=''ee-shut''>data_type:
-  unsigned int16<input type=''checkbox'' class=''ee-toggle''></label><ul><li><span
+'<li><label>"B1", unsigned int16<input type=''checkbox''></label><ul><li><span class=''ee-k''>id:</span><span
+  class=''ee-v''>B1</span></li><li><label>data_type: unsigned int16<input type=''checkbox''></label><ul><li><span
   class=''ee-k''>type:</span><span class=''ee-v''>PixelType</span></li><li><span class=''ee-k''>max:</span><span
   class=''ee-v''>65535</span></li><li><span class=''ee-k''>min:</span><span class=''ee-v''>0</span></li><li><span
   class=''ee-k''>precision:</span><span class=''ee-v''>int</span></li></ul></li></ul></li>'


### PR DESCRIPTION
This is an implementation of the pure CSS collapsing mentioned in #5.

## Context

Container objects like lists and dicts are collapsible to hide their contents. This is currently implemented by injecting a small JS script into the HTML repr that handles on-click events for the parent container (a stealthy checkbox) by setting CSS styles that hide/show the child elements. That works fine, but it requires extra CSS classes and I've always been a little hesitant about injecting JS.

## This PR

The [`has:` CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/:has) allows for the same behavior without any JS by styling the container and its children depending on whether the container's checkbox is ticked. This isn't possible without that selector because the styling is based on the `input` child of the `label` parent, which isn't representable with older CSS selectors (the input *must* be a child of the label to tie them together without using IDs, as described in #5). 

I previously avoided this solution because `has` was relatively new and poorly supported, but it's [now listed as](https://caniuse.com/css-has) "Newly available across major browsers" with 93.4% of users supported.

The benefits of this change are:
- Simpler and cleaner
- Marginally smaller reprs (about 8% reduction in file size)
- Avoid potential issues if JS is disabled or restricted for security/privacy (this hasn't come up)

