### PR TITLE
Style updates

### DIFF
--- a/eerepr/repr.py
+++ b/eerepr/repr.py
@@ -79,7 +79,7 @@ def _repr_html_(obj: EEObject) -> str:
     return (
         "<div>"
         f"<style>{css}</style>"
-        "<div class='ee'>"
+        "<div class='eerepr'>"
         f"<ul>{body}</ul>"
         "</div>"
         "</div>"

--- a/eerepr/static/css/style.css
+++ b/eerepr/static/css/style.css
@@ -1,6 +1,6 @@
 :root {
   --font-color-primary: var(--jp-content-font-color0, rgba(0, 0, 0, 1));
-  --font-color-secondary: var(--jp-content-font-color2, rgba(0, 0, 0, 0.6));
+  --font-color-secondary: var(--jp-content-font-color2, rgba(0, 0, 0, 0.7));
   --font-color-accent: rgba(123, 31, 162, 1);
   --border-color: var(--jp-border-color2, #e0e0e0);
   --background-color: var(--jp-layout-color0, white);
@@ -29,10 +29,12 @@ body.vscode-dark {
   max-height: 600px;
   border: 1px solid var(--border-color);
   font-family: monospace;
+  font-size: 12px;
 }
 
 .eerepr li {
   list-style-type: none;
+  margin: 0;
 }
 
 .eerepr ul {

--- a/eerepr/static/css/style.css
+++ b/eerepr/static/css/style.css
@@ -20,7 +20,7 @@ body.vscode-dark {
   --background-color-row-odd: #313131;
 }
 
-.ee {
+.eerepr {
   padding: 1em;
   line-height: 1.5em;
   min-width: 300px;
@@ -31,26 +31,26 @@ body.vscode-dark {
   font-family: monospace;
 }
 
-.ee li {
+.eerepr li {
   list-style-type: none;
 }
 
-.ee ul {
+.eerepr ul {
   padding-left: 1.5em !important;
   margin: 0;
 }
 
-.ee > ul {
+.eerepr > ul {
   padding-left: 0 !important;
 }
 
-.ee summary {
+.eerepr summary {
   color: var(--font-color-secondary);
   cursor: pointer;
   margin: 0;
 }
 
-.ee summary:hover {
+.eerepr summary:hover {
   color: var(--font-color-primary);
 }
 
@@ -63,7 +63,7 @@ body.vscode-dark {
   color: var(--font-color-primary);
 }
 
-.ee details > summary::before {
+.eerepr details > summary::before {
   content: '▼';
   display: inline-block;
   margin-right: 6px;
@@ -71,14 +71,14 @@ body.vscode-dark {
   transform: rotate(-90deg);
 }
 
-.ee details[open] > summary::before {
+.eerepr details[open] > summary::before {
   transform: rotate(0deg);
 }
 
-.ee details summary::-webkit-details-marker {
+.eerepr details summary::-webkit-details-marker {
   display:none;
 }
 
-.ee details summary {
+.eerepr details summary {
   list-style-type: none;
 }

--- a/eerepr/static/css/style.css
+++ b/eerepr/static/css/style.css
@@ -12,7 +12,7 @@ html[theme="dark"],
 body[data-theme="dark"],
 body.vscode-dark {
   --font-color-primary: rgba(255, 255, 255, 1);
-  --font-color-secondary: rgba(255, 255, 255, 0.6);
+  --font-color-secondary: rgba(255, 255, 255, 0.7);
   --font-color-accent: rgb(173, 132, 190);
   --border-color: #2e2e2e;
   --background-color: #111111;
@@ -29,7 +29,7 @@ body.vscode-dark {
   max-height: 600px;
   border: 1px solid var(--border-color);
   font-family: monospace;
-  font-size: 12px;
+  font-size: 14px;
 }
 
 .eerepr li {
@@ -54,6 +54,7 @@ body.vscode-dark {
 
 .eerepr summary:hover {
   color: var(--font-color-primary);
+  background-color: var(--background-color-row-odd)
 }
 
 .ee-k {

--- a/tests/data/test_full_repr.yml
+++ b/tests/data/test_full_repr.yml
@@ -1,25 +1,26 @@
 "<div><style>:root {\n  --font-color-primary: var(--jp-content-font-color0, rgba(0,\
   \ 0, 0, 1));\n  --font-color-secondary: var(--jp-content-font-color2, rgba(0, 0,\
-  \ 0, 0.6));\n  --font-color-accent: rgba(123, 31, 162, 1);\n  --border-color: var(--jp-border-color2,\
+  \ 0, 0.7));\n  --font-color-accent: rgba(123, 31, 162, 1);\n  --border-color: var(--jp-border-color2,\
   \ #e0e0e0);\n  --background-color: var(--jp-layout-color0, white);\n  --background-color-row-even:\
   \ var(--jp-layout-color1, white);\n  --background-color-row-odd: var(--jp-layout-color2,\
   \ #eeeeee);\n}\n\nhtml[theme=\"dark\"],\nbody[data-theme=\"dark\"],\nbody.vscode-dark\
   \ {\n  --font-color-primary: rgba(255, 255, 255, 1);\n  --font-color-secondary:\
-  \ rgba(255, 255, 255, 0.6);\n  --font-color-accent: rgb(173, 132, 190);\n  --border-color:\
+  \ rgba(255, 255, 255, 0.7);\n  --font-color-accent: rgb(173, 132, 190);\n  --border-color:\
   \ #2e2e2e;\n  --background-color: #111111;\n  --background-color-row-even: #111111;\n\
-  \  --background-color-row-odd: #313131;\n}\n\n.ee {\n  padding: 1em;\n  line-height:\
+  \  --background-color-row-odd: #313131;\n}\n\n.eerepr {\n  padding: 1em;\n  line-height:\
   \ 1.5em;\n  min-width: 300px;\n  max-width: 1200px;\n  overflow-y: scroll;\n  max-height:\
   \ 600px;\n  border: 1px solid var(--border-color);\n  font-family: monospace;\n\
-  }\n\n.ee li {\n  list-style-type: none;\n}\n\n.ee ul {\n  padding-left: 1.5em !important;\n\
-  \  margin: 0;\n}\n\n.ee > ul {\n  padding-left: 0 !important;\n}\n\n.ee summary\
-  \ {\n  color: var(--font-color-secondary);\n  cursor: pointer;\n  margin: 0;\n}\n\
-  \n.ee summary:hover {\n  color: var(--font-color-primary);\n}\n\n.ee-k {\n  color:\
-  \ var(--font-color-accent);\n  margin-right: 6px;\n}\n\n.ee-v {\n  color: var(--font-color-primary);\n\
-  }\n\n.ee details > summary::before {\n  content: '▼';\n  display: inline-block;\n\
+  \  font-size: 14px;\n}\n\n.eerepr li {\n  list-style-type: none;\n  margin: 0;\n\
+  }\n\n.eerepr ul {\n  padding-left: 1.5em !important;\n  margin: 0;\n}\n\n.eerepr\
+  \ > ul {\n  padding-left: 0 !important;\n}\n\n.eerepr summary {\n  color: var(--font-color-secondary);\n\
+  \  cursor: pointer;\n  margin: 0;\n}\n\n.eerepr summary:hover {\n  color: var(--font-color-primary);\n\
+  \  background-color: var(--background-color-row-odd)\n}\n\n.ee-k {\n  color: var(--font-color-accent);\n\
+  \  margin-right: 6px;\n}\n\n.ee-v {\n  color: var(--font-color-primary);\n}\n\n\
+  .eerepr details > summary::before {\n  content: '▼';\n  display: inline-block;\n\
   \  margin-right: 6px;\n  transition: transform 0.2s;\n  transform: rotate(-90deg);\n\
-  }\n\n.ee details[open] > summary::before {\n  transform: rotate(0deg);\n}\n\n.ee\
-  \ details summary::-webkit-details-marker {\n  display:none;\n}\n\n.ee details summary\
-  \ {\n  list-style-type: none;\n}\n</style><div class='ee'><ul><li><details><summary>List\
+  }\n\n.eerepr details[open] > summary::before {\n  transform: rotate(0deg);\n}\n\n\
+  .eerepr details summary::-webkit-details-marker {\n  display:none;\n}\n\n.eerepr\
+  \ details summary {\n  list-style-type: none;\n}\n</style><div class='eerepr'><ul><li><details><summary>List\
   \ (40 elements)</summary><ul><li><details><summary>0: Image foo (1 band)</summary><ul><li><span\
   \ class='ee-k'>type:</span><span class='ee-v'>Image</span></li><li><span class='ee-k'>id:</span><span\
   \ class='ee-v'>foo</span></li><li><details><summary>bands: List (1 element)</summary><ul><li><details><summary>0:\


### PR DESCRIPTION
Closes #43

- Slight style tweaks with font opacity and implementing the hover background color from the Code Editor
- Explicitly set font-size and margins to avoid inheriting incompatible styles
- Use a longer class name for the top-level div to avoid clashes. The internal class names (`ee-k` and `ee-v`) are still short to reduce repr size (they add up when you have thousands of objects), but those are more unique already so I'm not too worried.