### PR TITLE
Allow setting all config options with `initialize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Better accessibility - reprs can be navigated by keyboard
 - Optimized dict sorting (3-10% faster)
 - Improved styling
+- Allow setting all configuration options through `eerepr.initialize`
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ eerepr.initialize()
 Running `eerepr.initialize` adds an HTML repr method to all Earth Engine objects. When you print them in an IPython environment, you'll see an interactive HTML repr instead of a boring old string repr. Simple as that!
 
 > [!TIP]
-> If you're using [geemap](https://github.com/gee-community/geemap), `eerepr` is automatically imported and activated by default!
+> If you're using `geemap>=0.35.2`, `eerepr` is automatically imported and initialized.
 
 ### Manually Rendering Objects
 
@@ -61,7 +61,7 @@ display(ee.FeatureCollection("LARSE/GEDI/GEDI02_A_002_INDEX").limit(3))
 ### Large Objects
 
 > [!CAUTION]
-> Just like in the Code Editor, printing huge collections can be slow and may hit memory limits. If a repr exceeds 100 Mb, `eerepr` will fallback to a string repr to avoid freezing the notebook. Adjust `eerepr.options.max_repr_mbs` to print larger objects.
+> Just like in the Code Editor, printing huge collections can be slow and may hit memory limits. If a repr exceeds 100 Mb, `eerepr` will fallback to a string repr to avoid freezing the notebook. You can adjust this limit with `eerepr.initialize(max_repr_mbs=...)`. 
 
 ## Caching
 

--- a/eerepr/__init__.py
+++ b/eerepr/__init__.py
@@ -1,5 +1,4 @@
-from eerepr.config import options
-from eerepr.repr import initialize, reset
+from eerepr.repr import initialize, options, reset
 
 __version__ = "0.0.4"
-__all__ = ["clear_cache", "initialize", "reset", "options"]
+__all__ = ["initialize", "reset", "options"]

--- a/eerepr/config.py
+++ b/eerepr/config.py
@@ -1,18 +1,13 @@
 from __future__ import annotations
 
-import json
+from dataclasses import dataclass
 
 
+@dataclass
 class Config:
-    def __init__(self, max_cache_size: int | None, max_repr_mbs: int):
-        self.max_cache_size = max_cache_size
-        self.max_repr_mbs = max_repr_mbs
+    max_cache_size: int | None = None
+    max_repr_mbs: int = 100
 
-    def __repr__(self):
-        return json.dumps(self.__dict__, indent=2)
-
-
-options = Config(
-    max_cache_size=None,
-    max_repr_mbs=100,
-)
+    def update(self, **kwargs) -> Config:
+        self.__dict__.update(**kwargs)
+        return self


### PR DESCRIPTION
Setting global config options should be done with `eerepr.initialize` instead of by directly accessing it. This makes that possible by updating the config singleton with the `initialize` params.