### PR TITLE
Long list optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-Nothing yet.
+### Performance
+
+- Avoid stringifying long lists that will definitely be truncated in the repr (~20% speedup when testing with a 25-image Sentinel-2 collection)
 
 ## [0.1.0] - 2025-01-10
 


### PR DESCRIPTION
## Related issue

None.

## Description

Lists are truncated to "List (n elements)" if the stringified
form is too long, but string conversion is expensive for long lists.
To avoid that, we can calculate the minimum possible string length
and skip stringifying if we exceed it. Based on benchmarking with
the S2 image collection, this is a 10 - 20% speedup for
convert_to_html.

The minimum length formula takes brackets, delimiters, and
whitespace into account, so e.g. the shortest possible 3-element
list is 9 characters: "[1, 1, 1]".

## Checklist

- [x] I have updated the CHANGELOG with any added features, changes, fixes, or removals.
