### PR TITLE
Use service account for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install hatch
-    - name: Write persistent EE credentials
-      env:
-        EE_TOKEN: ${{ secrets.EE_TOKEN }}
-      run: |
-        mkdir -p /home/runner/.config/earthengine
-        echo $EE_TOKEN > /home/runner/.config/earthengine/credentials
     - name: Test with pytest
+      env:
+        EE_SERVICE_ACCOUNT: ${{ secrets.EE_SERVICE_ACCOUNT }}
       run: |
-        hatch run test:all
-  
+          hatch run test:all
+    
   lint:
     runs-on: ubuntu-latest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,13 +66,22 @@ def object_cache():
 
 
 def pytest_sessionstart(session):
+    _init_ee_for_tests()
+
+
+def _init_ee_for_tests():
+    # Use the Github Service Account for CI tests
     if os.environ.get("GITHUB_ACTIONS"):
-        service_account = os.environ.get("EE_SERVICE_ACCOUNT")
-        credentials = ee.ServiceAccountCredentials(None, key_data=service_account)
+        key_data = os.environ.get("EE_SERVICE_ACCOUNT")
+        project_id = json.loads(key_data).get("project_id")
+        credentials = ee.ServiceAccountCredentials(None, key_data=key_data)
+    # Use stored persistent credentials for local tests
     else:
+        # Project should be parsed from credentials
+        project_id = None
         credentials = "persistent"
 
-    ee.Initialize(credentials=credentials)
+    ee.Initialize(credentials, project=project_id)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import json
+import os
 import warnings
 from collections import UserDict
 from pathlib import Path
@@ -65,7 +66,13 @@ def object_cache():
 
 
 def pytest_sessionstart(session):
-    ee.Initialize()
+    if os.environ.get("GITHUB_ACTIONS"):
+        service_account = os.environ.get("EE_SERVICE_ACCOUNT")
+        credentials = ee.ServiceAccountCredentials(None, key_data=service_account)
+    else:
+        credentials = "persistent"
+
+    ee.Initialize(credentials=credentials)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Related issue

## Description

As of [`earthengine-api==1.5.0`](https://github.com/google/earthengine-api/releases/tag/v1.5.0), `ee.Initialize` requires a `project`. I could have continued using the persistent token along with a project ID, but a service account should provide more control.

Note that the service account needs two roles to run tests:
- Earth Engine Resource Writer
- Service Usage Consumer

Local tests will still rely on user's persistent credentials, to allow contributors to run tests.

This is a quick fix to get CI back up and running, but I should consider switching to [workload identity federation](https://cloud.google.com/blog/products/identity-security/enabling-keyless-authentication-from-github-actions).

## Checklist

- [ ] I have updated the CHANGELOG with any added features, changes, fixes, or removals.
