### PR TITLE
Skip caching non-deterministic objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-Nothing yet!
+### Performance
+
+- Non-deterministic objects are no longer cached, rather than getting a unique attribute to force a cache miss. Negligible reduction in memory, unless you're caching huge shuffled lists.
 
 ## [0.1.1] - 2025-02-19
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -20,15 +20,13 @@ def test_caching(obj):
     assert cache.cache_info().hits == 1
 
 
-def test_nondeterministic_caching():
+def test_nondeterministic_uncached():
     """
-    ee.List.shuffle(seed=False) is nondeterministic. Make sure it misses the cache.
+    ee.List.shuffle(seed=False) is nondeterministic. Make sure it isn't cached.
     """
     eerepr.initialize()
     cache = eerepr.repr._repr_html_
 
-    assert cache.cache_info().misses == 0
     x = ee.List([0, 1, 2]).shuffle(seed=False)
     x._repr_html_()
-    x._repr_html_()
-    assert cache.cache_info().misses == 2
+    assert cache.cache_info().currsize == 0


### PR DESCRIPTION
## Related issue

## Description

Skipping the cache entirely is more straightforward and memory-efficient than making non-deterministic objects miss the cache with a custom attribute.

## Checklist

- [x] I have updated the CHANGELOG with any added features, changes, fixes, or removals.
