### PR TITLE
Clear the cache with `reset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- `eerepr.reset()` now clears the cache immediately instead of waiting for `eerepr.initialize()`.
+
 ### Performance
 
 - Non-deterministic objects are no longer cached, rather than getting a unique attribute to force a cache miss. Negligible reduction in memory, unless you're caching huge shuffled lists.

--- a/eerepr/repr.py
+++ b/eerepr/repr.py
@@ -100,7 +100,7 @@ def initialize(
     max_repr_mbs: int = 100,
     on_error: Literal["warn", "raise"] = "warn",
 ) -> None:
-    """Attach HTML repr methods to EE objects and set the cache size.
+    """Attach HTML repr methods to EE objects and initialize a cache.
 
     Re-running this function will reset the cache.
 
@@ -135,7 +135,11 @@ def initialize(
 
 
 def reset():
-    """Remove HTML repr methods added by eerepr to EE objects."""
+    """Remove HTML repr methods added by eerepr to EE objects and reset the cache."""
     for cls in reprs_set:
         if hasattr(cls, REPR_HTML):
             delattr(cls, REPR_HTML)
+
+    reprs_set.clear()
+    if isinstance(_repr_html_, _lru_cache_wrapper):
+        _repr_html_.cache_clear()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -30,3 +30,13 @@ def test_nondeterministic_uncached():
     x = ee.List([0, 1, 2]).shuffle(seed=False)
     x._repr_html_()
     assert cache.cache_info().currsize == 0
+
+
+def test_reset_cache():
+    """Test that the cache is correctly reset."""
+    eerepr.initialize()
+    cache = eerepr.repr._repr_html_
+    ee.Number(42)._repr_html_()
+    assert cache.cache_info().currsize == 1
+    eerepr.reset()
+    assert cache.cache_info().currsize == 0


### PR DESCRIPTION
## Description

`eerepr.reset()` now clears the cache immediately, instead of waiting for `eerepr.initialize()` and the garbage collector to do it.

## Checklist

- [x] I have updated the CHANGELOG with any added features, changes, fixes, or removals.
