### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,56 @@
+# Adapted from: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+name: Publish to PyPI
+on:
+    push:
+        tags:
+            # Publish when a tag is pushed
+            - '*'
+
+jobs:
+    build:
+        name: Build distribution
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                persist-credentials: false
+
+            - name: Set up Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: '3.x'
+
+            - name: Install hatch
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install hatch
+
+            - name: Build distribution
+              run: hatch build -c
+
+            - name: Store packages
+              uses: actions/upload-artifact@v4
+              with:
+                name: python-package-distributions
+                path: dist/
+                    
+    publish-to-pypi:
+        name: Publish to PyPI
+        runs-on: ubuntu-latest
+        needs:
+        - build
+        environment:
+            name: pypi
+            url: https://pypi.org/p/eerepr
+        permissions:
+            id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+        steps:
+        - name: Download dists
+          uses: actions/download-artifact@v4
+          with:
+            name: python-package-distributions
+            path: dist/
+        - name: Publish distribution to PyPI
+          uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Related issue

## Description

Sets up automatic publishing to PyPI on tag pushes.

See https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

## Checklist

- [ ] I have updated the CHANGELOG with any added features, changes, fixes, or removals.
