### PR TITLE
ci.yml: Test python 3.10 .. 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
     strategy:
       matrix:
         python-version: [
+            '3.8',
+            '3.9',
             '3.10',
             '3.11',
             '3.12',


### PR DESCRIPTION
EE is dropping support for python 3.9 and it has worked with 3.13 for quite a while.

Not quite there on python 3.14.
